### PR TITLE
fix: handle attributed rdf:li and prefer x-default in XMP find_text (#42)

### DIFF
--- a/crates/xifty-meta-xmp/src/lib.rs
+++ b/crates/xifty-meta-xmp/src/lib.rs
@@ -282,16 +282,63 @@ fn find_element(xml: &str, name: &str) -> Option<DecodedText> {
     let open = format!("<{name}>");
     if let Some(start) = xml.find(&open) {
         let body = &xml[start + open.len()..];
-        if let Some(li_start) = body.find("<rdf:li>") {
-            let li_body = &body[li_start + 8..];
-            let li_end = li_body.find("</rdf:li>")?;
+        let close = format!("</{name}>");
+        let element_end = body.find(&close);
+        // If the element contains an <rdf:Alt> block, prefer the xml:lang="x-default"
+        // alternative before falling back to the first <rdf:li>. Otherwise fall back
+        // to the first <rdf:li …> (attributed or bare) inside e.g. <rdf:Bag>/<rdf:Seq>.
+        let scan_slice = match element_end {
+            Some(end) => &body[..end],
+            None => body,
+        };
+        if let Some(alt_start) = scan_slice.find("<rdf:Alt") {
+            // Walk all rdf:li children in the Alt block; prefer x-default.
+            let alt_body = &scan_slice[alt_start..];
+            let mut first_li: Option<String> = None;
+            let mut x_default: Option<String> = None;
+            let mut cursor = alt_body;
+            while let Some((open_tag_end, body_start, li_value)) = next_rdf_li(cursor) {
+                // `open_tag_end` is the index of `>` for the opening tag (within `cursor`);
+                // `body_start` is the index just past it; both are relative to `cursor`.
+                let opening_tag = &cursor[..=open_tag_end];
+                let is_default = opening_tag.contains("xml:lang=\"x-default\"");
+                if first_li.is_none() {
+                    first_li = Some(li_value.clone());
+                }
+                if is_default {
+                    x_default = Some(li_value.clone());
+                    break;
+                }
+                // Advance past this <rdf:li>…</rdf:li>.
+                let consumed = match cursor[body_start..].find("</rdf:li>") {
+                    Some(end) => body_start + end + "</rdf:li>".len(),
+                    None => break,
+                };
+                cursor = &cursor[consumed..];
+            }
+            let preferred = x_default
+                .map(|v| (v, true))
+                .or_else(|| first_li.map(|v| (v, false)));
+            if let Some((value, is_default)) = preferred {
+                let note = if is_default {
+                    format!("decoded from xmp rdf:Alt x-default inside {name}")
+                } else {
+                    format!("decoded from xmp rdf:Alt rdf:li inside {name}")
+                };
+                return Some(DecodedText {
+                    value: xml_unescape(&value),
+                    note,
+                });
+            }
+        }
+        if let Some((_, body_start, li_value)) = next_rdf_li(scan_slice) {
+            let _ = body_start;
             return Some(DecodedText {
-                value: xml_unescape(&li_body[..li_end]),
+                value: xml_unescape(&li_value),
                 note: format!("decoded from xmp rdf:li inside {name}"),
             });
         }
-        let close = format!("</{name}>");
-        let end = body.find(&close)?;
+        let end = element_end?;
         return Some(DecodedText {
             value: xml_unescape(&body[..end]),
             note: format!("decoded from xmp element {name}"),
@@ -299,6 +346,25 @@ fn find_element(xml: &str, name: &str) -> Option<DecodedText> {
     }
 
     None
+}
+
+/// Locate the next `<rdf:li …>` element inside `body`, accepting both the bare
+/// `<rdf:li>` form and the attributed `<rdf:li xml:lang="x-default">` form.
+///
+/// Returns `(open_tag_gt_idx, body_start_idx, inner_value)` where the indices
+/// are offsets within `body`. The scan stops at the first `>` after `<rdf:li`;
+/// pathological attribute values containing an unescaped `>` would mis-terminate,
+/// but XMP producers entity-encode such content. A quick-xml migration is the
+/// right long-term answer — this keeps the file dependency-free per the plan.
+fn next_rdf_li(body: &str) -> Option<(usize, usize, String)> {
+    let li_start = body.find("<rdf:li")?;
+    let after_tag = &body[li_start..];
+    let gt_rel = after_tag.find('>')?;
+    let open_tag_gt_idx = li_start + gt_rel;
+    let body_start = open_tag_gt_idx + 1;
+    let inner = &body[body_start..];
+    let end = inner.find("</rdf:li>")?;
+    Some((open_tag_gt_idx, body_start, inner[..end].to_string()))
 }
 
 fn xml_unescape(value: &str) -> String {
@@ -327,5 +393,67 @@ mod tests {
         assert!(entries.iter().any(|entry| entry.tag_name == "Author"));
         assert!(entries.iter().any(|entry| entry.tag_name == "GPSLatitude"));
         assert!(entries.iter().all(|entry| !entry.notes.is_empty()));
+    }
+
+    #[test]
+    fn xmp_decoder_handles_rdf_alt_x_default_copyright() {
+        let entries = decode_packet(XmpPacket {
+            bytes: r#"<x:xmpmeta><rdf:Description><dc:rights><rdf:Alt><rdf:li xml:lang="x-default">© 2025 K</rdf:li></rdf:Alt></dc:rights></rdf:Description></x:xmpmeta>"#.as_bytes(),
+            container: "png",
+            offset_start: 0,
+            offset_end: 180,
+        });
+        let copyright = entries
+            .iter()
+            .find(|entry| entry.tag_name == "Copyright")
+            .expect("copyright entry present");
+        match &copyright.value {
+            TypedValue::String(value) => assert_eq!(value, "© 2025 K"),
+            other => panic!("expected string, got {other:?}"),
+        }
+        assert!(
+            copyright
+                .notes
+                .iter()
+                .any(|note| note.contains("rdf:Alt x-default")),
+            "expected x-default note, got {:?}",
+            copyright.notes
+        );
+    }
+
+    #[test]
+    fn xmp_decoder_handles_rdf_alt_x_default_description() {
+        let entries = decode_packet(XmpPacket {
+            bytes: br#"<x:xmpmeta><rdf:Description><dc:description><rdf:Alt><rdf:li xml:lang="x-default">A photo of a cat.</rdf:li></rdf:Alt></dc:description></rdf:Description></x:xmpmeta>"#,
+            container: "png",
+            offset_start: 0,
+            offset_end: 200,
+        });
+        let description = entries
+            .iter()
+            .find(|entry| entry.tag_name == "Description")
+            .expect("description entry present");
+        match &description.value {
+            TypedValue::String(value) => assert_eq!(value, "A photo of a cat."),
+            other => panic!("expected string, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn xmp_decoder_prefers_x_default_over_other_languages() {
+        let entries = decode_packet(XmpPacket {
+            bytes: r#"<x:xmpmeta><rdf:Description><dc:rights><rdf:Alt><rdf:li xml:lang="fr">© 2025 français</rdf:li><rdf:li xml:lang="x-default">© 2025 default</rdf:li></rdf:Alt></dc:rights></rdf:Description></x:xmpmeta>"#.as_bytes(),
+            container: "png",
+            offset_start: 0,
+            offset_end: 240,
+        });
+        let copyright = entries
+            .iter()
+            .find(|entry| entry.tag_name == "Copyright")
+            .expect("copyright entry present");
+        match &copyright.value {
+            TypedValue::String(value) => assert_eq!(value, "© 2025 default"),
+            other => panic!("expected string, got {other:?}"),
+        }
     }
 }

--- a/crates/xifty-meta-xmp/src/lib.rs
+++ b/crates/xifty-meta-xmp/src/lib.rs
@@ -437,6 +437,14 @@ mod tests {
             TypedValue::String(value) => assert_eq!(value, "A photo of a cat."),
             other => panic!("expected string, got {other:?}"),
         }
+        assert!(
+            description
+                .notes
+                .iter()
+                .any(|note| note.contains("rdf:Alt x-default")),
+            "expected x-default note, got {:?}",
+            description.notes
+        );
     }
 
     #[test]

--- a/specs/drafts/42-xmp-rdf-li-attributed.md
+++ b/specs/drafts/42-xmp-rdf-li-attributed.md
@@ -1,0 +1,60 @@
+<!-- loswf:plan -->
+# Plan #42: XMP find_text substring scan drops bag/alt values
+
+## Problem
+`xifty-meta-xmp::find_element` at `crates/xifty-meta-xmp/src/lib.rs:285` locates
+`rdf:li` items using the literal needle `"<rdf:li>"`. Lightroom, Capture One,
+Photoshop, and Bridge emit the canonical language-alternative form
+`<rdf:li xml:lang="x-default">…</rdf:li>`, which that literal never matches —
+so `find_element` falls through to the raw element-body branch, capturing the
+wrapper markup (`<rdf:Alt><rdf:li xml:lang="x-default">© 2025</rdf:li></rdf:Alt>`)
+rather than the inner value, and for `rdf:Alt` the `x-default` preference is
+never honored. This systematically corrupts or drops `copyright`
+(`dc:rights`), `description` (`dc:description`), and any future `rdf:Alt`- or
+attributed-`rdf:Seq`-backed field.
+
+## Approach
+Broaden the `rdf:li` match in `find_element` to accept both the bare
+`<rdf:li>` and the attributed `<rdf:li …>` forms, and when scanning an
+`rdf:Alt` block prefer the `xml:lang="x-default"` alternative before falling
+back to the first `rdf:li`. Keep the implementation dependency-free (no new
+crates) and mirror the existing substring-scan style in this file — the
+pattern already tolerates unprefixed attribute discovery in `find_attr`
+(`lib.rs:270-279`) so a symmetric extension for element-form `rdf:li` fits
+naturally. This is an isolated, targeted fix to the defect described in the
+investigator note; it intentionally stops short of pulling in `quick-xml` or
+rewriting the parser (that broader remediation is listed as an alternative
+in the issue but is out of scope for this fix).
+
+## Files to touch
+- `crates/xifty-meta-xmp/src/lib.rs` — broaden `find_element` (lines 281-302) to match `<rdf:li` with optional attributes and to prefer `xml:lang="x-default"` inside `rdf:Alt`; extend the `tests` module (line 313+) with fixtures covering the Lightroom/Photoshop element-form `rdf:Alt` layout for `dc:rights` and `dc:description`, plus an `rdf:Alt` with a non-default first `li` to prove `x-default` preference.
+
+## New files
+- None. All changes fit within the existing crate and its in-file tests.
+
+## Step-by-step
+1. In `crates/xifty-meta-xmp/src/lib.rs`, replace the literal `body.find("<rdf:li>")` scan at line 285 with a helper (e.g. `find_rdf_li(body)`) that locates the next `<rdf:li` token, advances past the tag's `>` terminator (handling both `<rdf:li>` and `<rdf:li xml:lang="x-default">`), then reads up to the next `</rdf:li>` — verifiable by a new unit test that feeds `<dc:rights><rdf:Alt><rdf:li xml:lang="x-default">© 2025</rdf:li></rdf:Alt></dc:rights>` and asserts the decoded value is exactly `© 2025` (not the wrapper markup).
+2. When the element body contains `<rdf:Alt`, scan all `rdf:li` children and prefer the one whose opening tag contains `xml:lang="x-default"`; fall back to the first `li` when no default exists — verifiable by a unit test with two `rdf:li` siblings (`xml:lang="fr"` first, `xml:lang="x-default"` second) asserting the `x-default` value is chosen.
+3. Update the `note` string in `DecodedText` for the new path to remain descriptive (e.g. `"decoded from xmp rdf:Alt x-default inside {name}"` vs the existing `"decoded from xmp rdf:li inside {name}"`) so provenance notes stay traceable — verifiable by asserting the note substring in the new tests.
+4. Keep existing `rdf:Seq` + bare `<rdf:li>` behavior unchanged (covered by the existing `dc:creator` test at line 320) — verifiable by the pre-existing `xmp_decoder_extracts_supported_fields` test continuing to pass unmodified.
+5. Run the full `validate[]` sequence locally and review any insta snapshot drift (XMP fixtures under the workspace) deliberately via `cargo insta review`, per SRS §4 — verifiable by all three gates going green.
+
+## Tests
+- Extend the in-crate `tests` module in `crates/xifty-meta-xmp/src/lib.rs`:
+  - `xmp_decoder_handles_rdf_alt_x_default_copyright` — `dc:rights` in element form with `xml:lang="x-default"`; asserts `Copyright` entry exists with the inner string only.
+  - `xmp_decoder_handles_rdf_alt_x_default_description` — `dc:description` same shape; asserts `Description` entry value matches expected text.
+  - `xmp_decoder_prefers_x_default_over_other_languages` — `rdf:Alt` with `fr` first and `x-default` second; asserts the `x-default` value is chosen.
+  - Negative regression: confirm `dc:creator` `rdf:Seq` + `<rdf:li>` path (existing test) still yields `Author` (no change required).
+- Workspace snapshot surfaces (`xifty-normalize`, CLI snapshot suites) may pick up newly populated `copyright` / `description` fields if any existing XMP fixtures use the element form; any resulting snapshot diffs must be reviewed via `cargo insta review` rather than blanket-accepted.
+
+## Validation
+- `cargo fmt --all -- --check`
+- `cargo test --workspace --all-features`
+- `cargo test -p xifty-ffi --all-features`
+
+## Risks
+- Overlap with issue #40 (`dc:subject` keyword `rdf:Seq` extraction). Issue #40 adds a brand-new `push_string` call for `dc:subject` and does not itself modify `find_element`; once #40 lands it will flow through the same `find_text` path, so the `find_element` broadening in this plan will directly benefit (and must not regress) keyword extraction. If #40 merges first, this PR should rebase cleanly; if this PR merges first, #40 gains a more capable parser with no rework needed. Builders should confirm no merge collision in `decode_packet` and that any new `dc:subject` test in #40 still passes against the broadened `find_element`.
+- Insta snapshot churn risk: if existing XMP fixtures carry element-form `dc:rights` or `dc:description` that silently produced garbage strings previously, those snapshots will now change to the correct inner value. That is a desired fix, but builders must review diffs — never blanket-accept — per SRS §4.
+- The broadened `<rdf:li` match must stop at the opening tag's `>` before consuming the body; care is needed so a pathological attribute value containing `>` (rare but legal when entity-encoded) does not mis-terminate. Keep the scan simple (find first `>` after `<rdf:li`) and document the assumption in a comment; a quick-xml migration remains the right long-term answer.
+- No FFI surface or schema change; `FFI_CONTRACT.md` and `CAPABILITIES.json` untouched.
+


### PR DESCRIPTION
## Summary
- Broadens `find_element` in `xifty-meta-xmp` to match both bare `<rdf:li>` and attributed `<rdf:li xml:lang="...">` forms, so Lightroom/Photoshop/Bridge-style `dc:rights` and `dc:description` packets decode to the inner value instead of wrapper markup.
- Adds `x-default` language preference inside `rdf:Alt` blocks with deterministic fallback to the first `<rdf:li>`.
- Preserves existing `dc:creator` `rdf:Seq` behavior (covered by the unchanged `xmp_decoder_extracts_supported_fields` test).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --all-features`
- [x] `cargo test -p xifty-ffi --all-features`
- [x] New unit tests: `xmp_decoder_handles_rdf_alt_x_default_copyright`, `xmp_decoder_handles_rdf_alt_x_default_description`, `xmp_decoder_prefers_x_default_over_other_languages`

Closes #42

Generated with [Claude Code](https://claude.com/claude-code)