### PR TITLE
docs: update for #73 — sam validate/build --region flag

### DIFF
--- a/examples/aws-sam-node/README.md
+++ b/examples/aws-sam-node/README.md
@@ -50,7 +50,9 @@ npm run invoke:gps
   produces a Lambda layer zip at `layer/xifty-node-layer.zip`
 
 - `npm run validate`
-  runs `sam validate --template-file template.yaml`
+  runs `sam validate --template-file template.yaml --region us-east-1`
+  (the `--region` flag is required; `sam validate` does not read `AWS_REGION`
+  from the environment)
 
 - `npm run invoke:fixture`
   invokes the handler locally against `fixtures/minimal/happy.jpg`

--- a/specs/archive/66-copyright-semantic-group-tags.md
+++ b/specs/archive/66-copyright-semantic-group-tags.md
@@ -1,0 +1,33 @@
+# Plan #66: fix validate copyright semantic group tag names
+
+## Problem
+`SEMANTIC_GROUPS` in `crates/xifty-validate/src/rules.rs` (lines 33–39) defines the `copyright` group with members `("xmp", "rights")` and `("iptc", "CopyrightNotice")`. Neither matches what the namespace parsers emit: `xifty-meta-xmp` emits `tag_name: "Copyright"` for `dc:rights` (see `crates/xifty-meta-xmp/src/lib.rs:122-124`) and `xifty-meta-iptc` emits `tag_name: "Copyright"` for dataset `(2, 116)` (see `crates/xifty-meta-iptc/src/lib.rs:102`). Because `detect_cross_namespace_disagreement` at `crates/xifty-validate/src/rules.rs:94-137` matches on `(namespace, tag_name)` equality, the XMP and IPTC copyright entries are never collected and genuinely conflicting copyright values across EXIF/XMP/IPTC produce zero conflicts in the report.
+
+## Approach
+Align the `copyright` group in `SEMANTIC_GROUPS` with the tag names actually emitted by the parsers — change both the XMP and IPTC entries to `"Copyright"`. Then add a unit test in `crates/xifty-validate/tests/conflicts.rs` (mirroring the structure of the existing `cross_namespace_string_disagreement_is_reported` test at lines 48-69) that synthesises EXIF/XMP/IPTC copyright entries with different values and asserts exactly one `copyright` conflict is reported. This mirrors the existing pattern and adds no new API surface.
+
+## Files to touch
+- `crates/xifty-validate/src/rules.rs` — update `SEMANTIC_GROUPS` copyright entries at lines 36-37.
+- `crates/xifty-validate/tests/conflicts.rs` — add cross-namespace copyright conflict test using the existing `string_entry` helper.
+
+## New files
+- None.
+
+## Step-by-step
+1. In `crates/xifty-validate/src/rules.rs` line 36, change `("xmp", "rights")` to `("xmp", "Copyright")` — XMP parser's emitted tag name.
+2. In `crates/xifty-validate/src/rules.rs` line 37, change `("iptc", "CopyrightNotice")` to `("iptc", "Copyright")` — IPTC parser's emitted tag name.
+3. In `crates/xifty-validate/tests/conflicts.rs`, add a test `cross_namespace_copyright_disagreement_is_reported` that builds three `string_entry` rows — `("exif","Copyright","(c) Alice")`, `("xmp","Copyright","(c) Bob")`, `("iptc","Copyright","(c) Carol")` — calls `build_report(Vec::new(), &entries)`, filters `report.conflicts` for `c.field == "copyright"`, and asserts exactly one conflict with a message that mentions at least two of the three namespaces.
+4. Optionally add a companion agreement test `copyright_agreement_across_namespaces_produces_no_conflict` (same three namespaces, identical values) asserting no `copyright` conflict is emitted — mirrors the existing agreement test at lines 122-140.
+
+## Tests
+- `crates/xifty-validate/tests/conflicts.rs` — new `cross_namespace_copyright_disagreement_is_reported` (required by acceptance criteria) and optional `copyright_agreement_across_namespaces_produces_no_conflict`.
+- Existing tests in the same file must continue to pass unchanged.
+
+## Validation
+- `cargo fmt --all -- --check`
+- `cargo test --workspace --all-features`
+- `cargo test -p xifty-ffi --all-features`
+
+## Risks
+- Other call sites or fixtures that encode the old tag strings `"rights"` or `"CopyrightNotice"` could exist; a repo-wide grep during build should confirm `SEMANTIC_GROUPS` is the only consumer. Snapshot tests under `crates/xifty-validate` that exercise fixtures containing XMP `dc:rights` or IPTC `(2,116)` may begin reporting a new `copyright` conflict — any insta snapshot changes must be reviewed manually (per guardrails), not blanket-accepted.
+- The conflict-emission path picks the first two canonicalised values in `BTreeMap` key order (`rules.rs:113-124`); the new test must assert membership rather than exact ordering of the two namespaces in the message.

--- a/specs/archive/73-lambda-sam-region-flag.md
+++ b/specs/archive/73-lambda-sam-region-flag.md
@@ -1,0 +1,38 @@
+<!-- loswf:plan -->
+# Plan #73: Lambda CI `sam validate` / `sam build` need explicit --region flag
+
+## Problem
+The `lambda-node-example` CI job's `Validate SAM template` step previously failed with "AWS Region was not found" because `sam validate` does not honour `AWS_REGION` / `AWS_DEFAULT_REGION` environment variables — it requires an explicit `--region` flag or a configured AWS profile. A top-level `env:` block in `.github/workflows/ci.yml` (added in commit `b3f82e8`) currently masks the failure on CI, but `examples/aws-sam-node/package.json:11` (`sam validate --template-file template.yaml`) and `.github/workflows/ci.yml:130` (`sam build --template-file template.yaml --build-dir .aws-sam/build`) still omit `--region`. Any developer running `npm run validate` locally without `AWS_REGION` exported hits the same failure, and the CI workaround is fragile.
+
+## Approach
+Add an explicit `--region us-east-1` flag to both call sites so the commands work regardless of ambient shell state. The region `us-east-1` matches the values already hardcoded in the workflow's top-level `env:` block at `.github/workflows/ci.yml:14-15`, so we are not introducing a new configuration value — just making the existing default explicit at each invocation. This mirrors the general "no ambient state" convention other steps in this workflow follow (e.g., explicit `--template-file` and `--build-dir` on `sam build`).
+
+## Files to touch
+- `examples/aws-sam-node/package.json` — line 11: add `--region us-east-1` to the `validate` script.
+- `.github/workflows/ci.yml` — line 130: add `--region us-east-1` to the `sam build` invocation.
+
+## New files
+- None.
+
+## Step-by-step
+1. Edit `examples/aws-sam-node/package.json` line 11 — change `"validate": "sam validate --template-file template.yaml"` to `"validate": "sam validate --template-file template.yaml --region us-east-1"`. Verifiable outcome: `grep -n "sam validate" examples/aws-sam-node/package.json` shows the `--region us-east-1` flag.
+2. Edit `.github/workflows/ci.yml` line 130 — change `run: sam build --template-file template.yaml --build-dir .aws-sam/build` to `run: sam build --template-file template.yaml --build-dir .aws-sam/build --region us-east-1`. Verifiable outcome: `grep -n "sam build" .github/workflows/ci.yml` shows the `--region us-east-1` flag.
+3. Run `cd examples/aws-sam-node && unset AWS_REGION AWS_DEFAULT_REGION && npm run validate` locally to confirm it succeeds without ambient region env vars (if AWS SAM CLI is installed). Verifiable outcome: command exits 0 with `is a valid SAM Template.` message.
+4. Push branch, open PR, observe `Lambda Node Example` CI job passes end-to-end (validate + build steps green).
+
+## Tests
+- No Rust test file changes required — this is a CI/scripts fix outside the cargo workspace.
+- Manual/CI verification: a clean `sam validate` run without `AWS_REGION` in the environment must succeed (step 3 above).
+- CI-level regression guard: the existing `Validate SAM template` and `Build AWS SAM application` workflow steps at `.github/workflows/ci.yml:109-111` and `:128-130` serve as the regression test — they must continue to pass after the change.
+
+## Validation
+- `cargo fmt --all -- --check` (from `.loswf/config.yaml` validate[0]) — unaffected but must pass.
+- `cargo test --workspace --all-features` (validate[1]) — unaffected but must pass.
+- `cargo test -p xifty-ffi --all-features` (validate[2]) — unaffected but must pass.
+- CI `Lambda Node Example` job must pass on the PR (the actual behaviour under test).
+
+## Risks
+- Hardcoding `us-east-1` at two more call sites increases duplication of the region literal (already hardcoded at `.github/workflows/ci.yml:14-15`). Acceptable: `sam validate` is a schema check that does not actually call into a region-specific API, so the literal value is inconsequential for correctness — it only needs to be a valid AWS region string. A future refactor could centralize this via a workflow-level variable or an npm config, but that is out of scope for this bug fix.
+- If a developer's local AWS profile defaults to a different region, the explicit `--region us-east-1` will override it. This is desirable for reproducible validation; no risk to real AWS resources because `sam validate` and `sam build` do not deploy anything.
+- Acceptance criterion "does not hardcode a region value in a way that would break local developer use" is satisfied: `sam validate` and `sam build` are offline operations, so the hardcoded region does not affect deploy targets (which use `sam deploy`, not touched here).
+

--- a/specs/archive/73-sam-region-flag.md
+++ b/specs/archive/73-sam-region-flag.md
@@ -1,0 +1,36 @@
+# Plan #73: Lambda CI `sam validate` / `sam build` need explicit --region flag
+
+## Problem
+The `lambda-node-example` CI job's `Validate SAM template` step previously failed with "AWS Region was not found" because `sam validate` does not honour `AWS_REGION` / `AWS_DEFAULT_REGION` environment variables — it requires an explicit `--region` flag or a configured AWS profile. A top-level `env:` block in `.github/workflows/ci.yml` (added in commit `b3f82e8`) currently masks the failure on CI, but `examples/aws-sam-node/package.json:11` (`sam validate --template-file template.yaml`) and `.github/workflows/ci.yml:130` (`sam build --template-file template.yaml --build-dir .aws-sam/build`) still omit `--region`. Any developer running `npm run validate` locally without `AWS_REGION` exported hits the same failure, and the CI workaround is fragile.
+
+## Approach
+Add an explicit `--region us-east-1` flag to both call sites so the commands work regardless of ambient shell state. The region `us-east-1` matches the values already hardcoded in the workflow's top-level `env:` block at `.github/workflows/ci.yml:14-15`, so we are not introducing a new configuration value — just making the existing default explicit at each invocation. This mirrors the general "no ambient state" convention other steps in this workflow follow (e.g., explicit `--template-file` and `--build-dir` on `sam build`).
+
+## Files to touch
+- `/Users/k/Projects/XIFty/examples/aws-sam-node/package.json` — line 11: add `--region us-east-1` to the `validate` script.
+- `/Users/k/Projects/XIFty/.github/workflows/ci.yml` — line 130: add `--region us-east-1` to the `sam build` invocation.
+
+## New files
+- None.
+
+## Step-by-step
+1. Edit `examples/aws-sam-node/package.json` line 11 — change `"validate": "sam validate --template-file template.yaml"` to `"validate": "sam validate --template-file template.yaml --region us-east-1"`. Verifiable outcome: `grep -n "sam validate" examples/aws-sam-node/package.json` shows the `--region us-east-1` flag.
+2. Edit `.github/workflows/ci.yml` line 130 — change `run: sam build --template-file template.yaml --build-dir .aws-sam/build` to `run: sam build --template-file template.yaml --build-dir .aws-sam/build --region us-east-1`. Verifiable outcome: `grep -n "sam build" .github/workflows/ci.yml` shows the `--region us-east-1` flag.
+3. Run `cd examples/aws-sam-node && unset AWS_REGION AWS_DEFAULT_REGION && npm run validate` locally to confirm it succeeds without ambient region env vars (if AWS SAM CLI is installed). Verifiable outcome: command exits 0 with `is a valid SAM Template.` message.
+4. Push branch, open PR, observe `Lambda Node Example` CI job passes end-to-end (validate + build steps green).
+
+## Tests
+- No Rust test file changes required — this is a CI/scripts fix outside the cargo workspace.
+- Manual/CI verification: a clean `sam validate` run without `AWS_REGION` in the environment must succeed (step 3 above).
+- CI-level regression guard: the existing `Validate SAM template` and `Build AWS SAM application` workflow steps at `.github/workflows/ci.yml:109-111` and `:128-130` serve as the regression test — they must continue to pass after the change.
+
+## Validation
+- `cargo fmt --all -- --check` (from `.loswf/config.yaml` validate[0]) — unaffected but must pass.
+- `cargo test --workspace --all-features` (validate[1]) — unaffected but must pass.
+- `cargo test -p xifty-ffi --all-features` (validate[2]) — unaffected but must pass.
+- CI `Lambda Node Example` job must pass on the PR (the actual behaviour under test).
+
+## Risks
+- Hardcoding `us-east-1` at two more call sites increases duplication of the region literal (already hardcoded at `.github/workflows/ci.yml:14-15`). Acceptable: `sam validate` is a schema check that does not actually call into a region-specific API, so the literal value is inconsequential for correctness — it only needs to be a valid AWS region string. A future refactor could centralize this via a workflow-level variable or an npm config, but that is out of scope for this bug fix.
+- If a developer's local AWS profile defaults to a different region, the explicit `--region us-east-1` will override it. This is desirable for reproducible validation; no risk to real AWS resources because `sam validate` and `sam build` do not deploy anything.
+- Acceptance criterion "does not hardcode a region value in a way that would break local developer use" is satisfied: `sam validate` and `sam build` are offline operations, so the hardcoded region does not affect deploy targets (which use `sam deploy`, not touched here).


### PR DESCRIPTION
## Summary

- Updates `examples/aws-sam-node/README.md` to document that `npm run validate` passes `--region us-east-1` explicitly to `sam validate`, and adds a note explaining that `sam validate` does not honour `AWS_REGION` from the environment.
- Archives planner drafts `specs/drafts/73-lambda-sam-region-flag.md` and `specs/drafts/73-sam-region-flag.md` to `specs/archive/`.
- Also archives the previously-orphaned `specs/drafts/66-copyright-semantic-group-tags.md` (issue #66 is already closed; the draft was sitting unarchived).

Closes #73. Linked to PR #76 (merge SHA 2c94d0c4f960cb841c86db1f00da544b23f257ab).

## Why

The `npm run validate` description in the example README showed the old command without `--region`, which would mislead developers reproducing the local invocation. The merged fix also added `--region us-east-1` to `sam build` in CI (`.github/workflows/ci.yml`) — that step has no adjacent prose to update.

## Test plan

- [ ] README matches the `package.json` `validate` script value (`sam validate --template-file template.yaml --region us-east-1`)
- [ ] Both `73-*` draft files absent from `specs/drafts/`, present in `specs/archive/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)