### PR TITLE
docs: capture npm 2FA + bypass-token requirements in release checklist

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -21,30 +21,78 @@ python3 tools/validate_schema_examples.py
 ```
 
 3. confirm `schemas/`, `CAPABILITIES.json`, and `SCHEMA_VERSION` still agree
-4. tag from the exact commit that contains the intended fix
-5. publish release notes that describe the shipped surface, not just merged code
+4. bump the workspace version, refresh `Cargo.lock`, commit, tag, push:
+
+```bash
+# in this repo, on main, after the feature PR has merged
+sed -i '' 's/^version = "0.1.X"/version = "0.1.Y"/' Cargo.toml   # workspace.package
+cargo build --workspace                                          # refreshes Cargo.lock
+git add Cargo.toml Cargo.lock
+git commit -m "Release core 0.1.Y"
+git push
+git tag -a v0.1.Y -m "Release core 0.1.Y"
+git push origin v0.1.Y
+```
+
+5. create a GitHub Release for the tag (`gh release create v0.1.Y --notes …`)
+   — this triggers `runtime-artifacts.yml`, which builds and uploads
+   `xifty-runtime-{macos-arm64,linux-x64}-v0.1.Y.tar.gz` assets.
+6. confirm both runtime artifacts landed on the release before announcing
+
+```bash
+gh release view v0.1.Y --json assets --jq '.assets[] | "\(.size)\t\(.name)"'
+```
+
+7. publish release notes that describe the shipped surface, not just merged code
 
 ## Node Package Release
 
-Before publishing `@xifty/xifty`:
+The Node binding has its own deep-dive in
+[`XIFtyNode/RELEASING.md`](https://github.com/XIFtySense/XIFtyNode/blob/main/RELEASING.md).
+The checklist below is the short version. **Read the deep-dive first if you
+have not published from this machine recently** — npm's 2FA / token /
+package-access rules have changed multiple times and the failure modes are
+non-obvious.
 
-1. build the release prebuilds
+### Pre-flight (one-time per machine, but verify each release)
+
+1. **`npm whoami`** returns `xifty`. If 401, run `npm login --auth-type=web`.
+2. **Package publishing-access mode** at
+   https://www.npmjs.com/package/@xifty/xifty/access is set to
+   *"Require two-factor authentication or a granular access token with
+   bypass 2fa enabled"* — **not** the *"… and disallow tokens"* option.
+   If you flip the radio you must confirm with your enrolled passkey in
+   the browser; the CLI cannot change this setting without an
+   authenticator-app TOTP.
+3. **`~/.npmrc` carries a granular access token with *Bypass 2FA*
+   checked**, scoped to `@xifty/xifty` with read-and-write. Tokens
+   without the bypass flag will get `EOTP` even though `npm whoami`
+   succeeds. Generate at https://www.npmjs.com/settings/~/tokens →
+   *Generate New Token* → *Granular Access Token*.
+4. **Docker is running** — the Linux-x64 prebuild is built in an Amazon
+   Linux 2023 container; without Docker the bundle ships only the macOS
+   prebuild.
+
+### Publish
 
 ```bash
-cd /Users/k/Projects/XIFtyNode
-npm run build:prebuilds
+cd /Users/k/Projects/XIFtyNode    # or wherever your XIFtyNode checkout lives
+npm version patch                 # 0.1.7 → 0.1.8 (auto-commits + tags)
+git push --follow-tags
+XIFTY_CORE_REF=v0.1.Y npm run publish:local   # pin to the core tag from above
 ```
 
-2. verify packaged contents
+`publish:local` runs prebuilds → `verify:package` → `verify:tarball` →
+`verify:linux-x64` → `npm publish`. Plan for ~5 min on a warm cache.
+
+### Post-publish
 
 ```bash
-npm run verify:package
-npm run verify:tarball
+npm view @xifty/xifty version dist-tags.latest --json
 ```
 
-3. if a local real-world fixture exists, smoke-test the packed tarball against it
-
-Example for the Sony XAVC regression path:
+If a local real-world fixture exists, smoke-test the *packed tarball*
+(not the repo checkout) against it:
 
 ```bash
 XIFTY_SMOKE_FIXTURE=/Users/k/Projects/XIFty/fixtures/local/C0242.MP4 \
@@ -53,12 +101,18 @@ XIFTY_SMOKE_NONZERO_FIELDS=video.bitrate,audio.sample_rate \
 npm run verify:tarball
 ```
 
-4. publish only after the tarball, not just the repo checkout, behaves correctly
-5. verify the registry after publish
+**Revoke the bypass-2fa publish token** at
+https://www.npmjs.com/settings/~/tokens after the release lands, unless
+you have another release coming up in the same window. These tokens can
+publish silently — treat them like a deploy key.
 
-```bash
-npm view @xifty/xifty version dist-tags.latest --json
-```
+### Common failure modes
+
+| Error | Cause |
+|---|---|
+| `EOTP — This operation requires a one-time password from your authenticator.` | Token missing *Bypass 2FA* flag, **or** package access mode is `mfa=publish` (disallow tokens). Both must be aligned. |
+| `403 Two-factor authentication is required to publish this package but an automation token was specified.` | Token is correct (bypass-2fa), but the package access setting is still `mfa=publish`. Flip the radio in the browser. |
+| `EPUBLISHCONFLICT` | Version already published. Bump again — npm versions are immutable. |
 
 ## Branch Protection
 


### PR DESCRIPTION
## Summary

The recent v0.1.6 / `@xifty/xifty@0.1.8` release surfaced two npm publishing footguns that aren't visible from the CLI alone:

- The package's *Publishing access* radio at https://www.npmjs.com/package/@xifty/xifty/access can be set to **"Require 2FA and disallow tokens"** — when it is, every CLI publish gets `EOTP` regardless of which token is presented, and there is no CLI escape hatch (the setting itself can only be flipped via passkey in the browser).
- A granular access token without the **Bypass 2FA** checkbox enabled gets the same `EOTP` even when the package access setting allows tokens.

Both must be aligned. Without this in writing the next release will rediscover it the hard way.

## Changes

- Expanded the Core Release section with the actual version-bump + tag + GitHub Release commands (the prior text said "tag from the exact commit" without the workspace-version-bump step that real releases require).
- Replaced the Node Package Release section with a pre-flight checklist + publish steps + token hygiene + a failure-mode table (`EOTP` / `403` / `EPUBLISHCONFLICT`).
- Added a deep-dive pointer to a new \`XIFtyNode/RELEASING.md\` (separate PR on that repo).

## Test plan

- [x] Followed against the v0.1.6 / 0.1.8 release I just shipped — every error in the table is one I personally hit, every step in the publish flow is what actually worked.
- [x] Linked to the deeper XIFtyNode/RELEASING.md (PR going up there in parallel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)