### PR TITLE
docs: surface OGG/Vorbis/Opus + audio in README + browser demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Current container coverage:
 - MP4 / MOV
 - M4A / M4B / M4P
 - FLAC
+- OGG (Vorbis / Opus)
 - AIFF / AIFC
 
 Current namespace coverage:
@@ -110,7 +111,8 @@ Current namespace coverage:
 - bounded iTunes (`ilst` atoms: Title, Artist, Album, AlbumArtist, Year, Genre, Comment, Composer, Lyrics, Encoder, TrackNumber, DiskNumber, Compilation, BeatsPerMinute, CoverArt)
 - bounded DJI drone telemetry from MP4 `udta` (flight pitch/yaw/roll, gimbal pitch/yaw/roll, speed XYZ, GPS location, camera model, serial number — surfaced under `drone.*`, `device.*`, and `location` in the normalized view)
 - selected Sony and Apple vendor metadata paths
-- bounded Vorbis comment (FLAC)
+- bounded Vorbis comment (FLAC, OGG)
+- bounded OGG framing (Vorbis + Opus ident headers, last-page granule duration, multiplexed-stream detection)
 - bounded FLAC stream info (sample rate, channels, bit depth, duration, embedded picture)
 - bounded AIFF stream info (sample rate, channels, bit depth, duration from `COMM` chunk)
 

--- a/demo/web/index.html
+++ b/demo/web/index.html
@@ -24,7 +24,7 @@
         </p>
         <div class="hero-notes">
           <span class="pill">Local processing only</span>
-          <span class="pill">Images + video containers</span>
+          <span class="pill">Images · Video · Audio</span>
           <span class="pill">DJI drone telemetry</span>
           <span class="pill">raw / interpreted / normalized / report</span>
         </div>
@@ -34,10 +34,14 @@
         <div class="upload-copy">
           <h2>Choose a file</h2>
           <p>
-            Browser-first support covers JPEG, TIFF, DNG, PNG, WebP, HEIF/HEIC,
-            and MP4/MOV (including DJI drone telemetry — flight + gimbal angles,
-            speed, GPS, model, serial — surfaced under <code>drone.*</code>,
-            <code>device.*</code>, and <code>location</code>).
+            Browser-first support covers <strong>images</strong> (JPEG, TIFF,
+            DNG, PNG, WebP, HEIF/HEIC), <strong>video</strong> (MP4, MOV — including
+            DJI drone telemetry: flight + gimbal angles, speed, GPS, model,
+            serial), and <strong>audio</strong> (M4A, FLAC, OGG with Vorbis/Opus,
+            AIFF/AIFC). Drone fields surface under <code>drone.*</code>,
+            <code>device.*</code>, and <code>location</code>; audio fields under
+            <code>audio.*</code>, <code>codec.audio</code>, and
+            <code>duration</code>.
           </p>
         </div>
         <label class="upload-zone" for="file-input" id="drop-zone">


### PR DESCRIPTION
The v0.1.7 release added OGG container support (Vorbis + Opus) but the user-facing copy never caught up.

## Changes

**README** — container coverage list adds \`OGG (Vorbis / Opus)\`. Vorbis-comment bullet extends from "(FLAC)" to "(FLAC, OGG)". New OGG-framing bullet lists what's surfaced (ident headers, last-page granule duration, multiplexed-stream detection).

**\`demo/web/index.html\`** — upload-panel copy regrouped as Images / Video / Audio with concrete format lists. Audio adds M4A, FLAC, OGG (Vorbis/Opus), AIFF/AIFC. Hero pill changes "Images + video containers" → "Images · Video · Audio".

The wasm bundle has shipped OGG since the v0.1.7 demo rebuild — this just catches the visible copy up. \`pages-demo.yml\` will rebuild the demo on merge automatically (\`demo/**\` is in the trigger paths).

## Test plan

- [x] Reads cleanly as markdown / HTML
- [x] No source code changes, no version bump needed
- [x] Format coverage matches actually-shipped support (cross-checked against the workspace tests that pass for OGG/Vorbis/Opus extraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)