### PR TITLE
demo: drone cockpit visualization + value-first hero

### DIFF
--- a/demo/web/app.js
+++ b/demo/web/app.js
@@ -286,6 +286,7 @@ function renderNormalized(payload) {
           )
           .join("")}
       </section>
+      ${renderDroneCockpit(fields)}
       ${renderFieldCatalog({
         kicker: "Expanded view",
         title: "Complete normalized field inventory",
@@ -299,6 +300,271 @@ function renderNormalized(payload) {
 
   structuredOutput.hidden = false;
   resultOutput.hidden = true;
+}
+
+// ---------------------------------------------------------------------------
+// Drone cockpit
+//
+// When `drone.*` fields are present in the normalized output, render a
+// cockpit-style instrument panel above the standard nutrition card. Three
+// SVG instruments visualise the spatial state at the moment of capture:
+//
+//   * Attitude indicator — flight pitch + flight roll combined into a classic
+//     artificial-horizon widget.
+//   * Compass — flight yaw, drawn as a rotating compass card with a fixed top
+//     reference notch.
+//   * Gimbal — top-down drone silhouette with an arrow showing where the
+//     camera is pointed (gimbal yaw) and a tilt badge for gimbal pitch.
+//
+// The point is to communicate "the drone was banking left, looking down" at a
+// glance, rather than asking the reader to reconstruct that mental picture
+// from a list of decimal degrees.
+// ---------------------------------------------------------------------------
+
+function renderDroneCockpit(fields) {
+  const flightPitch = numericField(fields, "drone.flight.pitch_deg");
+  const flightYaw = numericField(fields, "drone.flight.yaw_deg");
+  const flightRoll = numericField(fields, "drone.flight.roll_deg");
+  const gimbalPitch = numericField(fields, "drone.gimbal.pitch_deg");
+  const gimbalYaw = numericField(fields, "drone.gimbal.yaw_deg");
+  const gimbalRoll = numericField(fields, "drone.gimbal.roll_deg");
+  const speedX = numericField(fields, "drone.speed.x_mps");
+  const speedY = numericField(fields, "drone.speed.y_mps");
+  const speedZ = numericField(fields, "drone.speed.z_mps");
+  const serial = stringField(fields, "device.serial_number");
+  const model = stringField(fields, "device.model");
+  const locationField = fields["location"];
+
+  const hasFlight = flightPitch != null || flightYaw != null || flightRoll != null;
+  const hasGimbal = gimbalPitch != null || gimbalYaw != null || gimbalRoll != null;
+  const hasSpeed = speedX != null || speedY != null || speedZ != null;
+
+  // Only render the cockpit when we have drone-specific telemetry. We
+  // intentionally do NOT gate on device.model / device.serial_number
+  // because those are populated by ordinary EXIF too (every JPEG with a
+  // camera will carry them), and the cockpit panel is meant to be a
+  // signal-of-drone-content surface.
+  if (!hasFlight && !hasGimbal && !hasSpeed) {
+    return "";
+  }
+
+  const attitude = hasFlight
+    ? attitudeInstrument(flightPitch ?? 0, flightRoll ?? 0)
+    : "";
+  const compass = hasFlight ? compassInstrument(flightYaw ?? 0) : "";
+  const gimbal = hasGimbal
+    ? gimbalInstrument(gimbalPitch ?? 0, gimbalYaw ?? 0, gimbalRoll ?? 0)
+    : "";
+
+  const instruments = [attitude, compass, gimbal].filter(Boolean).join("");
+
+  const speedMagnitude =
+    hasSpeed
+      ? Math.sqrt((speedX ?? 0) ** 2 + (speedY ?? 0) ** 2 + (speedZ ?? 0) ** 2)
+      : null;
+  const speedReadout = hasSpeed
+    ? `${formatNumber(speedMagnitude, 2)} m/s <span class="cockpit-axis">(X ${formatNumber(speedX, 2)} · Y ${formatNumber(speedY, 2)} · Z ${formatNumber(speedZ, 2)})</span>`
+    : "—";
+
+  const locationCoords =
+    locationField?.value?.kind === "coordinates"
+      ? `${formatNumber(locationField.value.value.latitude, 4)}°, ${formatNumber(locationField.value.value.longitude, 4)}°`
+      : null;
+  const locationLink = locationCoords
+    ? `<a class="cockpit-map" href="https://www.openstreetmap.org/?mlat=${locationField.value.value.latitude}&mlon=${locationField.value.value.longitude}&zoom=15" target="_blank" rel="noopener">view on OSM ↗</a>`
+    : "";
+
+  const cameraIdentity = [model, serial && `SN ${serial}`].filter(Boolean).join(" · ") || "—";
+
+  return `
+    <section class="cockpit-panel" aria-label="Drone telemetry visualisation">
+      <header class="cockpit-header">
+        <p class="label-kicker">Drone telemetry</p>
+        <h3>Spatial state at capture</h3>
+        <p class="label-caption">Flight + gimbal angles, speed, GPS, and camera identity rendered live from the file's <code>drone.*</code>, <code>device.*</code>, and <code>location</code> fields.</p>
+      </header>
+      <div class="cockpit-instruments">
+        ${instruments || '<p class="cockpit-empty">No flight or gimbal angles in this file.</p>'}
+      </div>
+      <dl class="cockpit-summary">
+        <div>
+          <dt>Speed</dt>
+          <dd>${speedReadout}</dd>
+        </div>
+        <div>
+          <dt>Location</dt>
+          <dd>${locationCoords ? `${escapeHtml(locationCoords)} ${locationLink}` : "—"}</dd>
+        </div>
+        <div>
+          <dt>Camera</dt>
+          <dd>${escapeHtml(cameraIdentity)}</dd>
+        </div>
+      </dl>
+    </section>
+  `;
+}
+
+function numericField(fields, key) {
+  const v = fields[key]?.value;
+  if (!v) return null;
+  if (v.kind === "float" || v.kind === "integer") {
+    const n = Number(v.value);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function stringField(fields, key) {
+  const v = fields[key]?.value;
+  if (!v) return null;
+  if (v.kind === "string") return String(v.value);
+  return null;
+}
+
+function formatNumber(value, fractionDigits = 1) {
+  if (value == null || !Number.isFinite(value)) return "—";
+  const abs = Math.abs(value);
+  const sign = value < 0 ? "−" : value > 0 ? "+" : "";
+  return `${sign}${abs.toFixed(fractionDigits)}`;
+}
+
+// --- Attitude indicator (artificial horizon) ---
+//
+// A 140×140 widget. Outer black bezel. Inside, a circle clipped to the bezel
+// shows a sky/ground gradient that rotates with roll and slides vertically
+// with pitch (clamped so the horizon stays visible). A fixed centre wing
+// glyph + ladder-tick degrees overlay indicate the airframe reference.
+function attitudeInstrument(pitch, roll) {
+  const clampedPitch = Math.max(-30, Math.min(30, pitch));
+  const pitchOffset = clampedPitch * 1.4; // px per degree
+  return `
+    <div class="cockpit-instrument">
+      <svg viewBox="0 0 140 140" class="cockpit-svg" role="img" aria-label="Attitude indicator">
+        <defs>
+          <clipPath id="attitude-clip"><circle cx="70" cy="70" r="56" /></clipPath>
+        </defs>
+        <circle cx="70" cy="70" r="64" fill="#121412" />
+        <circle cx="70" cy="70" r="58" fill="#fffdf8" />
+        <g clip-path="url(#attitude-clip)" transform="rotate(${(-roll).toFixed(2)} 70 70)">
+          <!-- Sky covers from far above the bezel down to the horizon line. -->
+          <rect x="-60" y="-100" width="260" height="${(170 + pitchOffset).toFixed(2)}" fill="#5a8fb2" />
+          <!-- Ground covers from the horizon line down to far below the bezel. -->
+          <rect x="-60" y="${(70 + pitchOffset).toFixed(2)}" width="260" height="200" fill="#8a5a2b" />
+          <line x1="-60" y1="${(70 + pitchOffset).toFixed(2)}" x2="200" y2="${(70 + pitchOffset).toFixed(2)}" stroke="#fffdf8" stroke-width="1.6" />
+          ${[-20, -10, 10, 20]
+            .map((tick) => {
+              const y = 70 + pitchOffset - tick * 1.4;
+              const w = Math.abs(tick) === 20 ? 28 : 18;
+              return `<line x1="${70 - w / 2}" y1="${y}" x2="${70 + w / 2}" y2="${y}" stroke="#fffdf8" stroke-width="1" opacity="0.7" />`;
+            })
+            .join("")}
+        </g>
+        <circle cx="70" cy="70" r="58" fill="none" stroke="#121412" stroke-width="1.5" />
+        <!-- fixed wing reference -->
+        <line x1="38" y1="70" x2="58" y2="70" stroke="#1a1d1b" stroke-width="2.4" />
+        <line x1="82" y1="70" x2="102" y2="70" stroke="#1a1d1b" stroke-width="2.4" />
+        <circle cx="70" cy="70" r="2.5" fill="#1a1d1b" />
+      </svg>
+      <p class="cockpit-readout">
+        <span class="cockpit-readout-label">Attitude</span>
+        <strong>${formatNumber(pitch, 1)}° pitch · ${formatNumber(roll, 1)}° roll</strong>
+      </p>
+    </div>
+  `;
+}
+
+// --- Compass (heading) ---
+//
+// Outer bezel. Rotating compass card inside (rotates by -yaw so the card
+// shows the heading at the top notch). Cardinal letters + 30° tick marks.
+// Fixed red indicator notch at top.
+function compassInstrument(yaw) {
+  const cardinals = [
+    { label: "N", angle: 0 },
+    { label: "E", angle: 90 },
+    { label: "S", angle: 180 },
+    { label: "W", angle: 270 },
+  ];
+  const ticks = Array.from({ length: 12 }, (_, i) => i * 30);
+  return `
+    <div class="cockpit-instrument">
+      <svg viewBox="0 0 140 140" class="cockpit-svg" role="img" aria-label="Heading compass">
+        <circle cx="70" cy="70" r="64" fill="#121412" />
+        <circle cx="70" cy="70" r="58" fill="#fffdf8" />
+        <g transform="rotate(${(-yaw).toFixed(2)} 70 70)">
+          ${ticks
+            .map((angle) => {
+              const long = angle % 90 === 0;
+              const r1 = long ? 42 : 48;
+              const r2 = 56;
+              const rad = ((angle - 90) * Math.PI) / 180;
+              const x1 = 70 + Math.cos(rad) * r1;
+              const y1 = 70 + Math.sin(rad) * r1;
+              const x2 = 70 + Math.cos(rad) * r2;
+              const y2 = 70 + Math.sin(rad) * r2;
+              return `<line x1="${x1.toFixed(1)}" y1="${y1.toFixed(1)}" x2="${x2.toFixed(1)}" y2="${y2.toFixed(1)}" stroke="#1a1d1b" stroke-width="${long ? 2 : 1}" opacity="${long ? 1 : 0.5}" />`;
+            })
+            .join("")}
+          ${cardinals
+            .map(({ label, angle }) => {
+              const rad = ((angle - 90) * Math.PI) / 180;
+              const x = 70 + Math.cos(rad) * 32;
+              const y = 70 + Math.sin(rad) * 32;
+              return `<text x="${x.toFixed(1)}" y="${(y + 4).toFixed(1)}" text-anchor="middle" font-family="var(--mono)" font-weight="700" font-size="13" fill="${label === "N" ? "#1f6f4a" : "#1a1d1b"}">${label}</text>`;
+            })
+            .join("")}
+        </g>
+        <circle cx="70" cy="70" r="58" fill="none" stroke="#121412" stroke-width="1.5" />
+        <!-- fixed top notch -->
+        <polygon points="70,8 64,16 76,16" fill="#b8782e" stroke="#121412" stroke-width="1" />
+      </svg>
+      <p class="cockpit-readout">
+        <span class="cockpit-readout-label">Heading</span>
+        <strong>${formatNumber(yaw, 1)}°</strong>
+      </p>
+    </div>
+  `;
+}
+
+// --- Gimbal indicator ---
+//
+// Top-down drone silhouette (cross of four arms with rotors) inside a bezel.
+// A camera-direction arrow rotates by gimbal yaw (drone-relative). A pitch
+// badge shows the camera's tilt down/up. Communicates "where the camera is
+// looking from the drone's frame of reference".
+function gimbalInstrument(pitch, yaw, roll) {
+  return `
+    <div class="cockpit-instrument">
+      <svg viewBox="0 0 140 140" class="cockpit-svg" role="img" aria-label="Gimbal direction">
+        <circle cx="70" cy="70" r="64" fill="#121412" />
+        <circle cx="70" cy="70" r="58" fill="#fffdf8" />
+        <!-- drone silhouette: four arms -->
+        <g stroke="#5c665f" stroke-width="2.2" stroke-linecap="round" fill="none">
+          <line x1="46" y1="46" x2="94" y2="94" />
+          <line x1="94" y1="46" x2="46" y2="94" />
+        </g>
+        <!-- rotors -->
+        <g fill="#5c665f" opacity="0.55">
+          <circle cx="46" cy="46" r="7" />
+          <circle cx="94" cy="46" r="7" />
+          <circle cx="46" cy="94" r="7" />
+          <circle cx="94" cy="94" r="7" />
+        </g>
+        <!-- body -->
+        <rect x="60" y="60" width="20" height="20" rx="3" fill="#1a1d1b" />
+        <!-- camera direction arrow rotated by gimbal yaw -->
+        <g transform="rotate(${yaw.toFixed(2)} 70 70)">
+          <line x1="70" y1="70" x2="70" y2="22" stroke="#1f6f4a" stroke-width="3" stroke-linecap="round" />
+          <polygon points="70,14 64,28 76,28" fill="#1f6f4a" />
+        </g>
+        <circle cx="70" cy="70" r="58" fill="none" stroke="#121412" stroke-width="1.5" />
+      </svg>
+      <p class="cockpit-readout">
+        <span class="cockpit-readout-label">Gimbal</span>
+        <strong>${formatNumber(pitch, 1)}° pitch · ${formatNumber(yaw, 1)}° yaw · ${formatNumber(roll, 1)}° roll</strong>
+      </p>
+    </div>
+  `;
 }
 
 function renderInterpreted(payload) {

--- a/demo/web/index.html
+++ b/demo/web/index.html
@@ -16,32 +16,33 @@
   <body>
     <main class="page">
       <section class="hero">
-        <p class="eyebrow">XIFty Browser Demo</p>
-        <h1>Inspect metadata locally in your browser.</h1>
+        <p class="eyebrow">XIFty</p>
+        <h1>Make sense of your metadata.</h1>
         <p class="lede">
-          Drop in a supported file and XIFty will extract metadata without
-          uploading it anywhere.
+          Drop a photo, video, or audio file. XIFty turns the buried,
+          format-specific bytes into clean, normalized facts you can
+          actually use — locally, in your browser, without uploading
+          anything.
         </p>
         <div class="hero-notes">
           <span class="pill">Local processing only</span>
           <span class="pill">Images · Video · Audio</span>
           <span class="pill">DJI drone telemetry</span>
-          <span class="pill">raw / interpreted / normalized / report</span>
+          <span class="pill">raw · interpreted · normalized · report</span>
         </div>
       </section>
 
       <section class="panel upload-panel">
         <div class="upload-copy">
-          <h2>Choose a file</h2>
+          <h2>Try it</h2>
           <p>
-            Browser-first support covers <strong>images</strong> (JPEG, TIFF,
-            DNG, PNG, WebP, HEIF/HEIC), <strong>video</strong> (MP4, MOV — including
-            DJI drone telemetry: flight + gimbal angles, speed, GPS, model,
-            serial), and <strong>audio</strong> (M4A, FLAC, OGG with Vorbis/Opus,
-            AIFF/AIFC). Drone fields surface under <code>drone.*</code>,
-            <code>device.*</code>, and <code>location</code>; audio fields under
-            <code>audio.*</code>, <code>codec.audio</code>, and
-            <code>duration</code>.
+            Drop a file to see what XIFty surfaces. Works on
+            <strong>images</strong> (JPEG, TIFF, DNG, PNG, WebP, HEIF/HEIC),
+            <strong>video</strong> (MP4, MOV — including DJI drone telemetry),
+            and <strong>audio</strong> (M4A, FLAC, OGG with Vorbis/Opus,
+            AIFF/AIFC). Camera, capture time, GPS, dimensions, codec, drone
+            flight angles, audio sample rate, and more — all surfaced as stable
+            keys you can read straight off.
           </p>
         </div>
         <label class="upload-zone" for="file-input" id="drop-zone">
@@ -54,11 +55,12 @@
       <section class="panel state-panel" id="state-panel">
         <div class="state-copy">
           <p class="section-label" id="state-label">Ready</p>
-          <h2 id="state-title">Drop in a file to inspect everything XIFty can see.</h2>
+          <h2 id="state-title">Drop in a file and we'll make sense of it.</h2>
           <p id="state-detail">
-            The demo keeps extraction local, then lays out normalized facts,
-            interpreted fields, raw metadata, and report findings in separate
-            browsable views.
+            Everything stays in your browser. You'll get a normalized view
+            (clean keys for product code), an interpreted view (decoded
+            namespaces with their meaning), a raw view (the original bytes),
+            and a report view (any conflicts or warnings XIFty caught).
           </p>
         </div>
         <div class="state-aside">

--- a/demo/web/smoketest/tests/dji-cockpit.spec.ts
+++ b/demo/web/smoketest/tests/dji-cockpit.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "@playwright/test";
+import * as path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+const FIXTURE_PATH = path.resolve(REPO_ROOT, "fixtures/minimal/dji_mavic3.mp4");
+
+test("dji_mavic3.mp4 renders the drone cockpit panel", async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+
+  await page.goto("/?smoketest=1");
+  await page.setInputFiles("#file-input", FIXTURE_PATH);
+  await page.waitForSelector(".cockpit-panel", { state: "visible", timeout: 10_000 });
+
+  // Three instruments: attitude, heading, gimbal.
+  expect(await page.locator(".cockpit-instrument").count()).toBe(3);
+
+  // Each instrument has an SVG and a labelled readout.
+  expect(await page.locator(".cockpit-instrument .cockpit-svg").count()).toBe(3);
+
+  // Readouts carry the fixture values verbatim.
+  const readouts = (await page.locator(".cockpit-readout strong").allTextContents()).join(" | ");
+  expect(readouts).toContain("+0.9° pitch");      // flight pitch
+  expect(readouts).toContain("−3.9° roll");       // flight roll
+  expect(readouts).toContain("+175.5°");          // heading
+  expect(readouts).toContain("−31.2° pitch");     // gimbal pitch
+  expect(readouts).toContain("−2.3° yaw");        // gimbal yaw
+
+  // Summary strip carries identity + location.
+  const summary = await page.locator(".cockpit-summary").innerText();
+  expect(summary).toContain("FC3682");
+  expect(summary).toContain("53HQN4T0M5B7JW");
+  expect(summary).toContain("40.7922");
+  expect(summary).toContain("−73.9584");
+
+  // No console errors during render.
+  expect(consoleErrors).toEqual([]);
+});
+
+test("happy.jpg does not render the cockpit panel (no drone telemetry)", async ({ page }) => {
+  const FIXTURE = path.resolve(REPO_ROOT, "fixtures/minimal/happy.jpg");
+  await page.goto("/?smoketest=1");
+  await page.setInputFiles("#file-input", FIXTURE);
+  // Wait for either the cockpit to appear or the structured output to fully render.
+  await page.waitForSelector(".structured-output:not([hidden])", { timeout: 10_000 });
+  await page.waitForTimeout(200); // settle
+  expect(await page.locator(".cockpit-panel").count()).toBe(0);
+});

--- a/demo/web/styles.css
+++ b/demo/web/styles.css
@@ -768,3 +768,153 @@ body {
     padding: 0.8rem;
   }
 }
+
+/* ---------------------------------------------------------------------------
+   Drone cockpit panel
+   --------------------------------------------------------------------------- */
+
+.cockpit-panel {
+  max-width: 46rem;
+  margin: 0 auto;
+  border: 1.5px solid rgba(26, 29, 27, 0.7);
+  border-radius: 1.2rem;
+  background: linear-gradient(180deg, #fffaf0 0%, #fffdf8 60%);
+  color: #121412;
+  overflow: hidden;
+  box-shadow: 0 18px 48px rgba(31, 28, 19, 0.08);
+}
+
+.cockpit-header {
+  padding: 1rem 1.1rem 0.95rem;
+  border-bottom: 3px solid #121412;
+  background:
+    linear-gradient(180deg, rgba(184, 121, 46, 0.08), transparent),
+    #fffdf8;
+}
+
+.cockpit-header h3 {
+  margin: 0;
+  font-size: clamp(1.5rem, 3vw, 2.2rem);
+  line-height: 0.94;
+  letter-spacing: -0.04em;
+}
+
+.cockpit-instruments {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.2rem;
+  padding: 1.4rem 1.2rem;
+  border-bottom: 1.5px solid rgba(26, 29, 27, 0.18);
+}
+
+.cockpit-instrument {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.cockpit-svg {
+  width: 100%;
+  max-width: 160px;
+  height: auto;
+  aspect-ratio: 1 / 1;
+  filter: drop-shadow(0 6px 12px rgba(31, 28, 19, 0.18));
+}
+
+.cockpit-readout {
+  margin: 0;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.cockpit-readout-label {
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.cockpit-readout strong {
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.cockpit-empty {
+  margin: 0;
+  padding: 1.5rem;
+  text-align: center;
+  color: var(--muted);
+  font-style: italic;
+  grid-column: 1 / -1;
+}
+
+.cockpit-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.cockpit-summary > div {
+  padding: 0.85rem 1.1rem;
+  border-right: 1px solid rgba(18, 20, 18, 0.18);
+  border-top: 1px solid rgba(18, 20, 18, 0.18);
+}
+
+.cockpit-summary > div:first-child {
+  border-top: 0;
+}
+
+.cockpit-summary > div:last-child {
+  border-right: 0;
+}
+
+.cockpit-summary dt {
+  margin: 0 0 0.3rem;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.cockpit-summary dd {
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 0.9rem;
+  letter-spacing: -0.01em;
+  word-break: break-word;
+}
+
+.cockpit-axis {
+  display: block;
+  margin-top: 0.2rem;
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.cockpit-map {
+  display: inline-block;
+  margin-left: 0.4rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent-soft);
+}
+
+.cockpit-map:hover {
+  border-bottom-color: var(--accent);
+}
+
+@media (max-width: 540px) {
+  .cockpit-summary > div {
+    border-right: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a cockpit-style visualization (attitude indicator, heading compass, gimbal indicator) under the structured-output drone block when DJI flight/gimbal/speed fields are present. Pure inline SVG, no external libs.
- Re-applies the value-first hero rework that was lost when PR #91 merged only the first of two commits ("Make sense of your metadata.").
- Bundles a Playwright regression covering both the render path (DJI fixture) and the non-render path (plain JPEG).

## Test plan
- [x] \`npx playwright test dji-cockpit\` (2 passed)
- [x] Manual: drop \`fixtures/minimal/dji_mavic3.mp4\` in the demo, confirm three instruments render with correct geometry
- [x] Manual: drop \`fixtures/minimal/happy.jpg\`, confirm no cockpit panel appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)