### PR TITLE
Release core 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-cli"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "clap",
  "flate2",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-container-aiff"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
  "xifty-source",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-container-flac"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
  "xifty-source",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-container-isobmff"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
  "xifty-source",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-container-jpeg"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
  "xifty-source",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-container-ogg"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
  "xifty-source",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-container-png"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
  "xifty-source",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-container-riff"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
  "xifty-source",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-container-tiff"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
  "xifty-source",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "serde",
  "thiserror",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-detect"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
  "xifty-source",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-ffi"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-cli",
  "xifty-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-json"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "serde_json",
  "xifty-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-meta-apple"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "plist",
  "xifty-container-tiff",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-meta-exif"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-container-jpeg",
  "xifty-container-tiff",
@@ -937,42 +937,42 @@ dependencies = [
 
 [[package]]
 name = "xifty-meta-icc"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-meta-iptc"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-meta-itunes"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-meta-quicktime"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-meta-rtmd"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-meta-sony"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-container-tiff",
  "xifty-core",
@@ -981,21 +981,21 @@ dependencies = [
 
 [[package]]
 name = "xifty-meta-vorbis-comment"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-meta-xmp"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-normalize"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
  "xifty-policy",
@@ -1003,28 +1003,28 @@ dependencies = [
 
 [[package]]
 name = "xifty-policy"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-source"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-validate"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-wasm"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "serde_json",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["XIFty Contributors"]
 
 [workspace.dependencies]


### PR DESCRIPTION
Workspace bump for the v0.1.8 release. New since v0.1.7:

- #93 — DJI drone telemetry from JPG XMP packets (\`drone-dji:*\` namespace)
- #92 — Browser demo cockpit visualisation
- #91 — OGG/Vorbis/Opus demo coverage docs

After merge: tag \`v0.1.8\` to trigger Runtime Artifacts upload, then bump \`@xifty/xifty\` in XIFtyNode to consume \`XIFTY_CORE_REF=v0.1.8\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)