### PR TITLE
docs: surface DJI JPG support in demo + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Current namespace coverage:
 - bounded IPTC
 - bounded QuickTime
 - bounded iTunes (`ilst` atoms: Title, Artist, Album, AlbumArtist, Year, Genre, Comment, Composer, Lyrics, Encoder, TrackNumber, DiskNumber, Compilation, BeatsPerMinute, CoverArt)
-- bounded DJI drone telemetry from MP4 `udta` (flight pitch/yaw/roll, gimbal pitch/yaw/roll, speed XYZ, GPS location, camera model, serial number — surfaced under `drone.*`, `device.*`, and `location` in the normalized view)
+- bounded DJI drone telemetry from MP4 `udta` and JPG XMP `drone-dji:*` (flight pitch/yaw/roll, gimbal pitch/yaw/roll, speed XYZ, GPS location, camera model, serial number, plus absolute/relative altitude on JPG — surfaced under `drone.*`, `device.*`, and `location` in the normalized view)
 - selected Sony and Apple vendor metadata paths
 - bounded Vorbis comment (FLAC, OGG)
 - bounded OGG framing (Vorbis + Opus ident headers, last-page granule duration, multiplexed-stream detection)

--- a/demo/web/index.html
+++ b/demo/web/index.html
@@ -38,11 +38,11 @@
           <p>
             Drop a file to see what XIFty surfaces. Works on
             <strong>images</strong> (JPEG, TIFF, DNG, PNG, WebP, HEIF/HEIC),
-            <strong>video</strong> (MP4, MOV — including DJI drone telemetry),
-            and <strong>audio</strong> (M4A, FLAC, OGG with Vorbis/Opus,
-            AIFF/AIFC). Camera, capture time, GPS, dimensions, codec, drone
-            flight angles, audio sample rate, and more — all surfaced as stable
-            keys you can read straight off.
+            <strong>video</strong> (MP4, MOV), and
+            <strong>audio</strong> (M4A, FLAC, OGG with Vorbis/Opus, AIFF/AIFC).
+            Camera, capture time, GPS, dimensions, codec, audio sample rate,
+            and DJI drone telemetry from either a Mavic JPG or MP4 — all
+            surfaced as stable keys you can read straight off.
           </p>
         </div>
         <label class="upload-zone" for="file-input" id="drop-zone">


### PR DESCRIPTION
## Summary
v0.1.8 / #93 added drone-dji XMP extraction from JPG, but the surrounding copy still told users DJI telemetry was MP4-only. The demo's WASM bundle already builds the new code path; this just lines up the marketing.

- \`demo/web/index.html\`: drop-zone copy now mentions drone telemetry from a Mavic JPG or MP4.
- \`README.md\`: capability list expanded — DJI from MP4 \`udta\` *and* JPG XMP \`drone-dji:*\`, with the new altitude fields called out.

## Verified
\`cargo run -p xifty-cli extract /path/to/DJI_0009.JPG --view normalized\` now returns \`drone.flight.yaw_deg\`, \`drone.gimbal.yaw_deg\`, and \`location\` from a single Mavic JPG drop-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)