### PR TITLE
fix(source): mmap large files instead of buffering whole Vec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,6 +1021,7 @@ dependencies = [
 name = "xifty-source"
 version = "0.1.8"
 dependencies = [
+ "memmap2",
  "xifty-core",
 ]
 

--- a/crates/xifty-source/Cargo.toml
+++ b/crates/xifty-source/Cargo.toml
@@ -6,3 +6,4 @@ license.workspace = true
 
 [dependencies]
 xifty-core = { path = "../xifty-core" }
+memmap2 = "0.9"

--- a/crates/xifty-source/src/lib.rs
+++ b/crates/xifty-source/src/lib.rs
@@ -1,30 +1,104 @@
-use std::{fs, path::Path};
+use std::{fmt, fs, path::Path, sync::Arc};
+
+use memmap2::Mmap;
 use xifty_core::{SourceRef, XiftyError};
 
-#[derive(Debug, Clone)]
+/// Backing storage for [`SourceBytes`].
+///
+/// Either an in-memory `Vec<u8>` (used by callers that already have the bytes,
+/// e.g. browser/WASM contexts) or a memory-mapped region from a path. The
+/// mmap variant lets the OS page bytes in on demand and evict clean pages
+/// under memory pressure, which keeps multi-gigabyte inputs (e.g. 4 GB DJI
+/// drone MP4s) under the AWS Lambda 3 GB ceiling — `std::fs::read` would
+/// allocate the entire file into the heap up front and OOM.
+enum SourceInner {
+    Owned(Vec<u8>),
+    Mapped(Mmap),
+}
+
+impl SourceInner {
+    fn bytes(&self) -> &[u8] {
+        match self {
+            SourceInner::Owned(v) => v.as_slice(),
+            SourceInner::Mapped(m) => &m[..],
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct SourceBytes {
     pub source: SourceRef,
-    bytes: Vec<u8>,
+    inner: Arc<SourceInner>,
 }
 
 impl SourceBytes {
+    /// Wrap an already-loaded byte buffer. Used when bytes are produced
+    /// outside the filesystem (browser uploads, WASM, in-memory fixtures).
     pub fn new(path: impl AsRef<Path>, bytes: Vec<u8>) -> Self {
         let path = path.as_ref();
         let source = SourceRef {
             path: path.to_path_buf(),
             size_bytes: bytes.len() as u64,
         };
-        Self { source, bytes }
+        Self {
+            source,
+            inner: Arc::new(SourceInner::Owned(bytes)),
+        }
     }
 
+    /// Open `path` and back the `SourceBytes` with a memory map instead of
+    /// reading the whole file into a `Vec<u8>`. Falls back to an empty owned
+    /// buffer for zero-length files (some platforms reject mmap of length 0).
     pub fn from_path(path: impl AsRef<Path>) -> Result<Self, XiftyError> {
         let path = path.as_ref();
-        let bytes = fs::read(path)?;
-        Ok(Self::new(path, bytes))
+        let file = fs::File::open(path)?;
+        let metadata = file.metadata()?;
+        let size_bytes = metadata.len();
+
+        let inner = if size_bytes == 0 {
+            SourceInner::Owned(Vec::new())
+        } else {
+            // SAFETY: mmap is unsafe because external mutation of the mapped
+            // file (truncation, writes by another process) would race with
+            // readers. XIFty treats `SourceBytes` as a read-only view of the
+            // input file for the duration of extraction; callers do not mutate
+            // the file while a `SourceBytes` is alive.
+            match unsafe { Mmap::map(&file) } {
+                Ok(mmap) => SourceInner::Mapped(mmap),
+                // Some platforms / filesystems refuse to mmap empty or
+                // pseudo-files even when metadata reports a non-zero size.
+                // Fall back to a plain read so we still produce a valid view.
+                Err(_) => SourceInner::Owned(fs::read(path)?),
+            }
+        };
+
+        let actual_len = inner.bytes().len() as u64;
+        let source = SourceRef {
+            path: path.to_path_buf(),
+            size_bytes: actual_len,
+        };
+        Ok(Self {
+            source,
+            inner: Arc::new(inner),
+        })
     }
 
     pub fn bytes(&self) -> &[u8] {
-        &self.bytes
+        self.inner.bytes()
+    }
+}
+
+impl fmt::Debug for SourceBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match &*self.inner {
+            SourceInner::Owned(_) => "Owned",
+            SourceInner::Mapped(_) => "Mapped",
+        };
+        f.debug_struct("SourceBytes")
+            .field("path", &self.source.path)
+            .field("size_bytes", &self.source.size_bytes)
+            .field("backing", &kind)
+            .finish()
     }
 }
 
@@ -114,5 +188,63 @@ mod tests {
         assert_eq!(cursor.read_u16(0, Endian::Little).unwrap(), 0x0201);
         assert_eq!(cursor.read_u32(0, Endian::Big).unwrap(), 0x01020304);
         assert_eq!(cursor.absolute_offset(2), 10);
+    }
+
+    #[test]
+    fn source_bytes_new_uses_owned_storage() {
+        let bytes = vec![1u8, 2, 3, 4, 5];
+        let source = SourceBytes::new("/tmp/in-memory.bin", bytes.clone());
+        assert_eq!(source.bytes(), bytes.as_slice());
+        assert_eq!(source.source.size_bytes, 5);
+        assert!(matches!(&*source.inner, SourceInner::Owned(_)));
+    }
+
+    #[test]
+    fn source_bytes_from_path_maps_file() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("xifty-source-mmap-{}.bin", std::process::id()));
+        let payload: Vec<u8> = (0..=255u8).collect();
+        std::fs::write(&path, &payload).unwrap();
+
+        let source = SourceBytes::from_path(&path).unwrap();
+        assert_eq!(source.bytes(), payload.as_slice());
+        assert_eq!(source.source.size_bytes, payload.len() as u64);
+        assert!(matches!(&*source.inner, SourceInner::Mapped(_)));
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn source_bytes_from_path_handles_empty_file() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("xifty-source-empty-{}.bin", std::process::id()));
+        std::fs::write(&path, b"").unwrap();
+
+        let source = SourceBytes::from_path(&path).unwrap();
+        assert!(source.bytes().is_empty());
+        assert_eq!(source.source.size_bytes, 0);
+        // Empty files fall back to owned storage because some platforms
+        // refuse to mmap a zero-length region.
+        assert!(matches!(&*source.inner, SourceInner::Owned(_)));
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn source_bytes_clone_shares_backing_storage() {
+        let bytes = vec![9u8; 32];
+        let a = SourceBytes::new("/tmp/clone.bin", bytes);
+        let b = a.clone();
+        // Same Arc pointee — clones do not duplicate the underlying buffer.
+        assert!(std::ptr::eq(a.bytes().as_ptr(), b.bytes().as_ptr()));
+    }
+
+    #[test]
+    fn source_bytes_debug_redacts_contents() {
+        let source = SourceBytes::new("/tmp/dbg.bin", vec![0u8; 4]);
+        let rendered = format!("{source:?}");
+        assert!(rendered.contains("SourceBytes"));
+        assert!(rendered.contains("size_bytes"));
+        assert!(rendered.contains("Owned"));
     }
 }


### PR DESCRIPTION
## Context

`SourceBytes::from_path` called `std::fs::read`, loading the entire input file into a heap-allocated `Vec<u8>` before any parsing started. In production (kstore-platform's `ProcessVideo` Lambda) this OOMs on multi-gigabyte inputs — specifically 2.8-4 GB DJI drone MP4s against the 3 GB Lambda memory ceiling. The downstream symptom was `xifty io error: out of memory` from `extract`, while the streamed ffmpeg thumbnail step (which never buffers the full file) succeeded on the same input.

## Fix

Back `from_path` with `memmap2::Mmap` instead of `fs::read`:

- The OS pages bytes in on demand and can evict clean pages under memory pressure. Resident memory stays far below file size, which is what gets us under the Lambda ceiling.
- `SourceBytes::new(path, Vec<u8>)` is preserved verbatim as `SourceInner::Owned` for callers that already have bytes (browser/WASM uploads, in-memory fixtures).
- The public surface — `pub source: SourceRef` and `bytes() -> &[u8]` — is unchanged. Every caller in the workspace (`xifty-detect`, `xifty-cli`, and every `xifty-container-*` crate) compiles and tests green without modification.

## Edge cases

- **Empty files**: some platforms reject `mmap` of length 0. Detected via `metadata.len() == 0` and routed to `SourceInner::Owned(Vec::new())`.
- **`Mmap::map` failure**: falls back to `fs::read` so we don't break on pseudo-files or filesystems that refuse mmap.
- **`Debug`**: hand-implemented (`Mmap` is not `Debug`); prints path, size, and backing kind without dumping bytes.
- **`Clone`**: cheap — the inner storage lives behind `Arc`.

## OS page-fault behavior (for future readers)

Memory mapping does not allocate `file_size` bytes of RSS. The kernel maps the file into the process's virtual address space and faults pages in only when they are touched. Pages that haven't been read recently and haven't been written are *clean* and the kernel can drop them under memory pressure (the page cache will re-read from disk if they're touched again). This is precisely the behavior we need for the Lambda case: a 4 GB MP4 being parsed metadata-first only ever needs a small working set resident.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo test -p xifty-source` — 6 passed (4 new tests covering owned construction, mmap-backed from_path, empty-file fallback, `Arc`-shared cloning, and `Debug` formatting)
- `cargo test -p xifty-detect` — 3 passed (exercises `from_path` against real fixtures)
- `cargo test` across all `xifty-container-*` crates — green
- `cargo build --workspace --all-targets` — green
- One pre-existing `clippy::len_without_is_empty` lint on `Cursor::len` exists on `main` and is not in scope for this PR.

## Out of scope

No version bump. No npm publish. The XIFtyNode side is a separate follow-up the requester is handling once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)