### PR TITLE
Release core 0.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-cli"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "clap",
  "flate2",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-container-aiff"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
  "xifty-source",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-container-flac"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
  "xifty-source",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-container-isobmff"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
  "xifty-source",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-container-jpeg"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
  "xifty-source",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-container-ogg"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
  "xifty-source",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-container-png"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
  "xifty-source",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-container-riff"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
  "xifty-source",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-container-tiff"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
  "xifty-source",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-core"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "serde",
  "thiserror",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-detect"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
  "xifty-source",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-ffi"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-cli",
  "xifty-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-json"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "serde_json",
  "xifty-core",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-meta-apple"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "plist",
  "xifty-container-tiff",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "xifty-meta-exif"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-container-jpeg",
  "xifty-container-tiff",
@@ -946,42 +946,42 @@ dependencies = [
 
 [[package]]
 name = "xifty-meta-icc"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-meta-iptc"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-meta-itunes"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-meta-quicktime"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-meta-rtmd"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-meta-sony"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-container-tiff",
  "xifty-core",
@@ -990,21 +990,21 @@ dependencies = [
 
 [[package]]
 name = "xifty-meta-vorbis-comment"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-meta-xmp"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-normalize"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
  "xifty-policy",
@@ -1012,14 +1012,14 @@ dependencies = [
 
 [[package]]
 name = "xifty-policy"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-source"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "memmap2",
  "xifty-core",
@@ -1027,14 +1027,14 @@ dependencies = [
 
 [[package]]
 name = "xifty-validate"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "xifty-core",
 ]
 
 [[package]]
 name = "xifty-wasm"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "serde_json",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["XIFty Contributors"]
 
 [workspace.dependencies]

--- a/crates/xifty-cli/tests/snapshots/cli_contract__extract_happy_mp3_normalized.snap
+++ b/crates/xifty-cli/tests/snapshots/cli_contract__extract_happy_mp3_normalized.snap
@@ -1,0 +1,93 @@
+---
+source: crates/xifty-cli/tests/cli_contract.rs
+assertion_line: 919
+expression: "extract_json(\"happy.mp3\", ViewMode::Normalized)"
+---
+{
+  "input": {
+    "container": "mp3",
+    "detected_format": "mp3",
+    "path": "happy.mp3"
+  },
+  "normalized": {
+    "fields": [
+      {
+        "confidence": 0.949999988079071,
+        "field": "duration",
+        "sources": [
+          {
+            "container": "mp3",
+            "namespace": "mp3",
+            "notes": [
+              "derived from MPEG frame count and sample rate"
+            ],
+            "path": "mpeg_audio_frame"
+          }
+        ],
+        "value": {
+          "kind": "float",
+          "value": 1.303125
+        }
+      },
+      {
+        "confidence": 0.949999988079071,
+        "field": "audio.channels",
+        "sources": [
+          {
+            "container": "mp3",
+            "namespace": "mp3",
+            "notes": [
+              "derived from MPEG audio frame header"
+            ],
+            "path": "mpeg_audio_frame"
+          }
+        ],
+        "value": {
+          "kind": "integer",
+          "value": 2
+        }
+      },
+      {
+        "confidence": 0.949999988079071,
+        "field": "audio.sample_rate",
+        "sources": [
+          {
+            "container": "mp3",
+            "namespace": "mp3",
+            "notes": [
+              "derived from MPEG audio frame header"
+            ],
+            "path": "mpeg_audio_frame"
+          }
+        ],
+        "value": {
+          "kind": "integer",
+          "value": 44100
+        }
+      },
+      {
+        "confidence": 0.949999988079071,
+        "field": "audio.bit_depth",
+        "sources": [
+          {
+            "container": "mp3",
+            "namespace": "mp3",
+            "notes": [
+              "fixed 16-bit per MPEG audio decoder output convention (not tag-derived)"
+            ],
+            "path": "mpeg_audio_frame"
+          }
+        ],
+        "value": {
+          "kind": "integer",
+          "value": 16
+        }
+      }
+    ]
+  },
+  "report": {
+    "conflicts": [],
+    "issues": []
+  },
+  "schema_version": "0.1.0"
+}

--- a/crates/xifty-cli/tests/snapshots/cli_contract__extract_real_camera_mp4_interpreted.snap
+++ b/crates/xifty-cli/tests/snapshots/cli_contract__extract_real_camera_mp4_interpreted.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/xifty-cli/tests/cli_contract.rs
-assertion_line: 478
+assertion_line: 793
 expression: output
 ---
 {
@@ -465,11 +465,79 @@ expression: output
     "conflicts": [
       {
         "field": "captured_at",
-        "message": "multiple candidates disagreed; selected CreateDate from rtmd"
+        "message": "multiple candidates disagreed; selected CreateDate from rtmd",
+        "sources": [
+          {
+            "namespace": "rtmd",
+            "provenance": {
+              "container": "mp4",
+              "namespace": "rtmd",
+              "offset_end": 25170432,
+              "offset_start": 25168484,
+              "path": "non_real_time_meta"
+            },
+            "tag_id": "CreateDate",
+            "tag_name": "CreateDate",
+            "value": {
+              "kind": "timestamp",
+              "value": "2026-04-16T06:34:34-08:00"
+            }
+          },
+          {
+            "namespace": "quicktime",
+            "provenance": {
+              "container": "mp4",
+              "namespace": "quicktime",
+              "notes": [
+                "derived from movie header creation time"
+              ]
+            },
+            "tag_id": "CreateDate",
+            "tag_name": "CreateDate",
+            "value": {
+              "kind": "timestamp",
+              "value": "2026-04-16T14:34:34"
+            }
+          }
+        ]
       },
       {
         "field": "created_at",
-        "message": "multiple candidates disagreed; selected CreateDate from rtmd"
+        "message": "multiple candidates disagreed; selected CreateDate from rtmd",
+        "sources": [
+          {
+            "namespace": "rtmd",
+            "provenance": {
+              "container": "mp4",
+              "namespace": "rtmd",
+              "offset_end": 25170432,
+              "offset_start": 25168484,
+              "path": "non_real_time_meta"
+            },
+            "tag_id": "CreateDate",
+            "tag_name": "CreateDate",
+            "value": {
+              "kind": "timestamp",
+              "value": "2026-04-16T06:34:34-08:00"
+            }
+          },
+          {
+            "namespace": "quicktime",
+            "provenance": {
+              "container": "mp4",
+              "namespace": "quicktime",
+              "notes": [
+                "derived from movie header creation time"
+              ]
+            },
+            "tag_id": "CreateDate",
+            "tag_name": "CreateDate",
+            "value": {
+              "kind": "timestamp",
+              "value": "2026-04-16T14:34:34"
+            }
+          }
+        ]
       }
     ],
     "issues": []

--- a/crates/xifty-cli/tests/snapshots/cli_contract__extract_real_camera_mp4_normalized.snap
+++ b/crates/xifty-cli/tests/snapshots/cli_contract__extract_real_camera_mp4_normalized.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/xifty-cli/tests/cli_contract.rs
+assertion_line: 784
 expression: output
 ---
 {
@@ -260,11 +261,79 @@ expression: output
     "conflicts": [
       {
         "field": "captured_at",
-        "message": "multiple candidates disagreed; selected CreateDate from rtmd"
+        "message": "multiple candidates disagreed; selected CreateDate from rtmd",
+        "sources": [
+          {
+            "namespace": "rtmd",
+            "provenance": {
+              "container": "mp4",
+              "namespace": "rtmd",
+              "offset_end": 25170432,
+              "offset_start": 25168484,
+              "path": "non_real_time_meta"
+            },
+            "tag_id": "CreateDate",
+            "tag_name": "CreateDate",
+            "value": {
+              "kind": "timestamp",
+              "value": "2026-04-16T06:34:34-08:00"
+            }
+          },
+          {
+            "namespace": "quicktime",
+            "provenance": {
+              "container": "mp4",
+              "namespace": "quicktime",
+              "notes": [
+                "derived from movie header creation time"
+              ]
+            },
+            "tag_id": "CreateDate",
+            "tag_name": "CreateDate",
+            "value": {
+              "kind": "timestamp",
+              "value": "2026-04-16T14:34:34"
+            }
+          }
+        ]
       },
       {
         "field": "created_at",
-        "message": "multiple candidates disagreed; selected CreateDate from rtmd"
+        "message": "multiple candidates disagreed; selected CreateDate from rtmd",
+        "sources": [
+          {
+            "namespace": "rtmd",
+            "provenance": {
+              "container": "mp4",
+              "namespace": "rtmd",
+              "offset_end": 25170432,
+              "offset_start": 25168484,
+              "path": "non_real_time_meta"
+            },
+            "tag_id": "CreateDate",
+            "tag_name": "CreateDate",
+            "value": {
+              "kind": "timestamp",
+              "value": "2026-04-16T06:34:34-08:00"
+            }
+          },
+          {
+            "namespace": "quicktime",
+            "provenance": {
+              "container": "mp4",
+              "namespace": "quicktime",
+              "notes": [
+                "derived from movie header creation time"
+              ]
+            },
+            "tag_id": "CreateDate",
+            "tag_name": "CreateDate",
+            "value": {
+              "kind": "timestamp",
+              "value": "2026-04-16T14:34:34"
+            }
+          }
+        ]
       }
     ],
     "issues": []

--- a/crates/xifty-cli/tests/snapshots/cli_contract__probe_happy_mp3.snap
+++ b/crates/xifty-cli/tests/snapshots/cli_contract__probe_happy_mp3.snap
@@ -1,0 +1,45 @@
+---
+source: crates/xifty-cli/tests/cli_contract.rs
+assertion_line: 165
+expression: "probe_json(\"happy.mp3\")"
+---
+{
+  "containers": [
+    {
+      "kind": "container",
+      "label": "mp3",
+      "offset_end": 20988,
+      "offset_start": 0
+    },
+    {
+      "kind": "tag",
+      "label": "id3v2",
+      "offset_end": 138,
+      "offset_start": 0,
+      "parent_label": "mp3"
+    },
+    {
+      "kind": "frame",
+      "label": "mpeg_audio_frame",
+      "offset_end": 20988,
+      "offset_start": 138,
+      "parent_label": "mp3"
+    }
+  ],
+  "input": {
+    "container": "mp3",
+    "detected_format": "mp3",
+    "path": "happy.mp3"
+  },
+  "report": {
+    "conflicts": [],
+    "issues": [
+      {
+        "code": "no_metadata_entries",
+        "message": "no supported metadata entries were decoded",
+        "severity": "info"
+      }
+    ]
+  },
+  "schema_version": "0.1.0"
+}


### PR DESCRIPTION
## Summary

- Bump workspace `0.1.8` → `0.1.9`
- Refresh insta snapshots after #87 (DJI udta MP4 telemetry adds `CreateDate` derived from movie header creation time) plus the new `happy_mp3` fixtures.

Headline change in this release is **#96 (mmap source)** — `SourceBytes::from_path` now memory-maps via `memmap2` instead of buffering into `Vec<u8>`. Unblocks metadata extraction on multi-GB MP4s under tight memory ceilings, e.g. AWS Lambda's 3 GB limit (where kstore-platform's ProcessVideo was OOM-ing on 2.8–4 GB DJI drone footage).

## Test plan
- [x] `cargo test --workspace` clean
- [x] `python3 tools/validate_schema_examples.py` clean
- [ ] After merge: tag `v0.1.9` + create GH release to trigger `runtime-artifacts.yml`