### PR TITLE
chore: ignore agent-runtime cruft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ node_modules/
 demo/web/pkg/
 .loswf/state/
 *.bak.*
+.claude/worktrees/
+.claude/scheduled_tasks.lock
+Untitled-*


### PR DESCRIPTION
## Summary
- Adds `.claude/worktrees/`, `.claude/scheduled_tasks.lock`, `Untitled-*` to `.gitignore`
- These are agent-runtime / IDE artifacts that have been showing up in `git status` and were misread by a downstream consumer as in-flight work

## Test plan
- [x] `git status` no longer surfaces these paths after gitignore takes effect