### PR TITLE
fix: emit filesystem-mtime fallback for PNG captured_at on all platforms

### DIFF
--- a/CAPABILITIES.json
+++ b/CAPABILITIES.json
@@ -152,7 +152,8 @@
         "xmp": "supported",
         "icc": "supported",
         "iptc": "bounded",
-        "png": "bounded"
+        "png": "bounded",
+        "filesystem": "supported"
       }
     },
     "webp": {

--- a/crates/xifty-cli/src/lib.rs
+++ b/crates/xifty-cli/src/lib.rs
@@ -1,5 +1,7 @@
 use flate2::read::ZlibDecoder;
-use std::{fs, io::Read, path::PathBuf, process::Command, time::SystemTime};
+#[cfg(target_os = "macos")]
+use std::process::Command;
+use std::{fs, io::Read, path::PathBuf, time::SystemTime};
 use xifty_container_aiff::{AiffContainer, parse as parse_aiff};
 use xifty_container_flac::{FlacContainer, parse as parse_flac};
 use xifty_container_id3::{Id3Container, parse as parse_mp3};
@@ -651,6 +653,18 @@ fn payload_slice(bytes: &[u8], absolute_offset: u64, len: usize) -> Option<&[u8]
     bytes.get(start..start + len)
 }
 
+/// Emit a filesystem-derived capture timestamp when a PNG carries no embedded
+/// `DateTimeOriginal` / `CreateDate`.
+///
+/// Two-tier precedence:
+/// 1. **Universal (all platforms):** filesystem `mtime` then `birthtime`/`ctime`.
+///    Runs whenever a PNG decode produced no capture-date candidate, so Linux,
+///    Windows, and macOS hosts all surface the host filesystem fallback.
+/// 2. **macOS Apple-screencap enrichment:** if the file is tagged as an Apple
+///    screen capture (via `xattr com.apple.metadata:kMDItemIsScreenCapture`)
+///    we prefer Spotlight's `kMDItemContentCreationDate` over the filesystem
+///    times. This branch is gated to `target_os = "macos"` because it shells
+///    out to macOS-only tools (`xattr`, `mdls`).
 fn add_filesystem_timestamp_fallbacks(
     entries: &mut Vec<MetadataEntry>,
     path: &std::path::Path,
@@ -660,59 +674,70 @@ fn add_filesystem_timestamp_fallbacks(
     let Some(metadata) = metadata else {
         return;
     };
-    if !matches!(format, Format::Png) || !is_apple_screen_capture(path) {
+    if !matches!(format, Format::Png) {
         return;
     }
     let has_captured_candidate = entries
         .iter()
         .any(|entry| matches!(entry.tag_name.as_str(), "DateTimeOriginal" | "CreateDate"));
-    if !has_captured_candidate {
-        if let Some((tag_id, value, note)) = apple_content_creation_timestamp(path)
-            .map(|value| {
-                (
-                    "AppleContentCreationDate",
-                    value,
-                    "Apple content creation date used because no embedded capture timestamp was decoded",
-                )
-            })
-            .or_else(|| {
-                metadata
-                    .modified()
-                    .ok()
-                    .and_then(system_time_to_utc_timestamp)
-                    .map(|value| {
-                        (
-                            "FileModifyDate",
-                            value,
-                            "filesystem modified time used because no embedded capture timestamp was decoded",
-                        )
-                    })
-            })
-            .or_else(|| {
-                metadata
-                    .created()
-                    .ok()
-                    .and_then(system_time_to_utc_timestamp)
-                    .map(|value| {
-                        (
-                            "FileCreateDate",
-                            value,
-                            "filesystem creation time used because no embedded capture timestamp was decoded",
-                        )
-                    })
-            })
-        {
-            entries.push(filesystem_timestamp_entry(
-                path,
-                tag_id,
-                "CreateDate",
+    if has_captured_candidate {
+        return;
+    }
+
+    #[cfg(target_os = "macos")]
+    let apple_candidate = if is_apple_screen_capture(path) {
+        apple_content_creation_timestamp(path).map(|value| {
+            (
+                "AppleContentCreationDate",
                 value,
-                note,
-            ));
-        }
+                "Apple content creation date used because no embedded capture timestamp was decoded",
+            )
+        })
+    } else {
+        None
+    };
+    #[cfg(not(target_os = "macos"))]
+    let apple_candidate: Option<(&'static str, String, &'static str)> = None;
+
+    if let Some((tag_id, value, note)) = apple_candidate
+        .or_else(|| {
+            metadata
+                .modified()
+                .ok()
+                .and_then(system_time_to_utc_timestamp)
+                .map(|value| {
+                    (
+                        "FileModifyDate",
+                        value,
+                        "filesystem modified time used because no embedded capture timestamp was decoded",
+                    )
+                })
+        })
+        .or_else(|| {
+            metadata
+                .created()
+                .ok()
+                .and_then(system_time_to_utc_timestamp)
+                .map(|value| {
+                    (
+                        "FileCreateDate",
+                        value,
+                        "filesystem creation time used because no embedded capture timestamp was decoded",
+                    )
+                })
+        })
+    {
+        entries.push(filesystem_timestamp_entry(
+            path,
+            tag_id,
+            "CreateDate",
+            value,
+            note,
+        ));
     }
 }
 
+#[cfg(target_os = "macos")]
 fn is_apple_screen_capture(path: &std::path::Path) -> bool {
     Command::new("xattr")
         .arg("-p")
@@ -723,6 +748,7 @@ fn is_apple_screen_capture(path: &std::path::Path) -> bool {
         .unwrap_or(false)
 }
 
+#[cfg(target_os = "macos")]
 fn apple_content_creation_timestamp(path: &std::path::Path) -> Option<String> {
     let output = Command::new("mdls")
         .arg("-raw")
@@ -737,6 +763,7 @@ fn apple_content_creation_timestamp(path: &std::path::Path) -> Option<String> {
     parse_mdls_utc_timestamp(std::str::from_utf8(&output.stdout).ok()?.trim())
 }
 
+#[cfg(target_os = "macos")]
 fn parse_mdls_utc_timestamp(value: &str) -> Option<String> {
     if value == "(null)" {
         return None;

--- a/crates/xifty-cli/tests/cli_contract.rs
+++ b/crates/xifty-cli/tests/cli_contract.rs
@@ -36,6 +36,61 @@ fn scrub_path(value: &mut Value) {
             value["input"]["path"] = Value::String(name);
         }
     }
+    scrub_filesystem_fallback_fields(value);
+}
+
+/// Redact filesystem-derived fallback fields so snapshots stay deterministic
+/// across hosts. Filesystem `mtime`/`birthtime` values vary per checkout, and
+/// the source `path` is an absolute path. We replace the timestamp value with
+/// `<filesystem>` and the source path with the file name, but only for
+/// entries whose source namespace is `filesystem` — embedded metadata is left
+/// untouched.
+fn scrub_filesystem_fallback_fields(value: &mut Value) {
+    let Some(fields) = value
+        .get_mut("normalized")
+        .and_then(|normalized| normalized.get_mut("fields"))
+        .and_then(|fields| fields.as_array_mut())
+    else {
+        return;
+    };
+    for field in fields {
+        let from_filesystem = field
+            .get("sources")
+            .and_then(|s| s.as_array())
+            .map(|sources| {
+                !sources.is_empty()
+                    && sources.iter().all(|source| {
+                        source.get("namespace").and_then(|n| n.as_str()) == Some("filesystem")
+                    })
+            })
+            .unwrap_or(false);
+        if !from_filesystem {
+            continue;
+        }
+        if let Some(sources) = field
+            .get_mut("sources")
+            .and_then(|sources| sources.as_array_mut())
+        {
+            for source in sources {
+                if let Some(path_value) = source.get_mut("path") {
+                    if let Some(path) = path_value.as_str().map(str::to_string) {
+                        let name = Path::new(&path)
+                            .file_name()
+                            .map(|n| n.to_string_lossy().into_owned())
+                            .unwrap_or(path);
+                        *path_value = Value::String(name);
+                    }
+                }
+            }
+        }
+        if let Some(value_obj) = field.get_mut("value") {
+            if value_obj.get("kind").and_then(|k| k.as_str()) == Some("timestamp") {
+                if let Some(v) = value_obj.get_mut("value") {
+                    *v = Value::String("<filesystem>".into());
+                }
+            }
+        }
+    }
 }
 
 fn extract_json(name: &str, view: ViewMode) -> Value {
@@ -315,6 +370,56 @@ fn apple_screenshot_png_uses_preserved_modified_time_when_birthtime_is_copy_time
             "kind": "timestamp",
             "value": "2025-03-24T21:09:11Z"
         })
+    );
+
+    let _ = fs::remove_file(temp_path);
+}
+
+#[test]
+fn png_without_embedded_datetime_falls_back_to_filesystem_mtime() {
+    use std::time::{Duration, SystemTime};
+
+    let fixture_path = fixture("no_exif.png");
+    let temp_path = std::env::temp_dir().join(format!(
+        "xifty-mtime-fallback-{}-{}.png",
+        std::process::id(),
+        chrono_like_test_suffix()
+    ));
+    fs::copy(&fixture_path, &temp_path).unwrap();
+
+    // Whole-second epoch so the formatted ISO-8601 string is stable across
+    // filesystems with second-resolution mtimes.
+    let target_unix_seconds: u64 = 1_705_320_000; // 2024-01-15T12:00:00Z
+    let target = SystemTime::UNIX_EPOCH + Duration::from_secs(target_unix_seconds);
+    let expected = "2024-01-15T12:00:00Z";
+
+    let file = fs::File::options().write(true).open(&temp_path).unwrap();
+    file.set_modified(target).unwrap();
+    drop(file);
+
+    let output = serde_json::to_value(
+        xifty_cli::extract_path(temp_path.clone(), ViewMode::Normalized).unwrap(),
+    )
+    .unwrap();
+    let output = normalized_map(&output);
+
+    assert_eq!(
+        output["captured_at"],
+        serde_json::json!({
+            "kind": "timestamp",
+            "value": expected,
+        }),
+        "captured_at should be sourced from filesystem mtime when no embedded \
+         capture timestamp is present"
+    );
+    assert_eq!(
+        output["created_at"],
+        serde_json::json!({
+            "kind": "timestamp",
+            "value": expected,
+        }),
+        "created_at should be sourced from filesystem mtime when no embedded \
+         capture timestamp is present"
     );
 
     let _ = fs::remove_file(temp_path);

--- a/crates/xifty-cli/tests/snapshots/cli_contract__extract_iptc_png_normalized.snap
+++ b/crates/xifty-cli/tests/snapshots/cli_contract__extract_iptc_png_normalized.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/xifty-cli/tests/cli_contract.rs
-assertion_line: 333
 expression: "extract_json(\"iptc.png\", ViewMode::Normalized)"
 ---
 {
@@ -11,6 +10,36 @@ expression: "extract_json(\"iptc.png\", ViewMode::Normalized)"
   },
   "normalized": {
     "fields": [
+      {
+        "confidence": 0.949999988079071,
+        "field": "captured_at",
+        "sources": [
+          {
+            "container": "source",
+            "namespace": "filesystem",
+            "path": "iptc.png"
+          }
+        ],
+        "value": {
+          "kind": "timestamp",
+          "value": "<filesystem>"
+        }
+      },
+      {
+        "confidence": 0.949999988079071,
+        "field": "created_at",
+        "sources": [
+          {
+            "container": "source",
+            "namespace": "filesystem",
+            "path": "iptc.png"
+          }
+        ],
+        "value": {
+          "kind": "timestamp",
+          "value": "<filesystem>"
+        }
+      },
       {
         "confidence": 0.949999988079071,
         "field": "author",

--- a/crates/xifty-cli/tests/snapshots/cli_contract__malformed_icc_png_report.snap
+++ b/crates/xifty-cli/tests/snapshots/cli_contract__malformed_icc_png_report.snap
@@ -17,11 +17,6 @@ expression: "extract_json(\"malformed_icc.png\", ViewMode::Report)"
         "message": "PNG iCCP payload could not be decompressed",
         "offset": 33,
         "severity": "warning"
-      },
-      {
-        "code": "no_metadata_entries",
-        "message": "no supported metadata entries were decoded",
-        "severity": "info"
       }
     ]
   },

--- a/crates/xifty-cli/tests/snapshots/cli_contract__malformed_png_report.snap
+++ b/crates/xifty-cli/tests/snapshots/cli_contract__malformed_png_report.snap
@@ -22,11 +22,6 @@ expression: "extract_json(\"malformed_chunk.png\", ViewMode::Report)"
         "code": "png_missing_iend",
         "message": "png stream ended without IEND chunk",
         "severity": "warning"
-      },
-      {
-        "code": "no_metadata_entries",
-        "message": "no supported metadata entries were decoded",
-        "severity": "info"
       }
     ]
   },

--- a/specs/drafts/105-linux-mtime-fallback.md
+++ b/specs/drafts/105-linux-mtime-fallback.md
@@ -1,0 +1,50 @@
+<!-- loswf:plan -->
+# Plan #105: linux-x64 prebuild — emit filesystem-mtime fallback for `captured_at` on all platforms
+
+## Problem
+On the linux-x64 prebuild, an image with no embedded EXIF/XMP capture timestamp returns no `captured_at` / `created_at` field — even though the host's filesystem mtime is set correctly. On darwin-arm64 the same call surfaces the mtime-derived field as expected. Investigation (see issue #105 confirmed comment) traces the regression to `crates/xifty-cli/src/lib.rs:649`, where `add_filesystem_timestamp_fallbacks` returns early unless `is_apple_screen_capture(path)` returns true. `is_apple_screen_capture` (lines 702–710) shells out to the macOS-only `xattr` tool; on Linux `Command::new("xattr").output()` returns `Err`, `.unwrap_or(false)` collapses to `false`, and the platform-neutral `metadata.modified()` / `metadata.created()` branches are never evaluated.
+
+## Approach
+Restructure `add_filesystem_timestamp_fallbacks` so the platform-neutral filesystem-mtime/ctime fallback runs unconditionally for PNGs that have no decoded capture-timestamp candidate, and treat the Apple `xattr`/`mdls` enrichment as an additive higher-confidence layer that is only attempted on macOS (or, more conservatively, only when `xattr`/`mdls` are actually available — same observable behavior). The PNG format gate is preserved (the existing surface is PNG-only and broadening it is out of scope for this bug). Confidence semantics, tag-name choices (`FileModifyDate` / `FileCreateDate`), and `MetadataEntry` shape are unchanged — only the gate is moved so the fallback can fire on Linux. The macOS-specific `apple_screenshot_png_uses_preserved_modified_time_when_birthtime_is_copy_time` test continues to pass on macOS, and a new portable test asserts the same `captured_at` / `created_at` emission on any host with a fresh tmpfile whose mtime has been set explicitly.
+
+## Files to touch
+- `crates/xifty-cli/src/lib.rs` — restructure `add_filesystem_timestamp_fallbacks` (line 640–700) to drop the `is_apple_screen_capture` precondition for the universal mtime/ctime fallback while keeping the Apple-screencap enrichment additive on macOS; gate the Apple enrichment behind `cfg!(target_os = "macos")` (or a `#[cfg(target_os = "macos")]` helper) so it never shells out on Linux.
+- `crates/xifty-cli/tests/cli_contract.rs` — add a portable (non-`target_os`-gated) test that copies `no_exif.png` to a tmpfile, sets a known mtime, calls `extract_path(..., ViewMode::Normalized)`, and asserts both `captured_at` and `created_at` are populated from the filesystem mtime.
+
+## New files
+- _(none)_ — no new modules; existing test file gets one additional `#[test]`.
+
+## Step-by-step
+1. In `crates/xifty-cli/src/lib.rs`, edit `add_filesystem_timestamp_fallbacks` (around line 640):
+   - Keep the `Some(metadata)` early-return and the `matches!(format, Format::Png)` format gate.
+   - Remove `|| !is_apple_screen_capture(path)` from the gate so all PNGs enter the body.
+   - Reorder the `or_else` chain so `apple_content_creation_timestamp(path)` is only attempted on macOS (wrap that branch in `cfg!(target_os = "macos")` or extract it into a `#[cfg(target_os = "macos")]` helper that returns `None` on non-macOS targets) and only when `is_apple_screen_capture(path)` is true (same enrichment trigger as today, but now scoped to one branch instead of gating the whole function).
+   - Preserve the existing precedence: AppleContentCreationDate (mac+screencap only) → FileModifyDate → FileCreateDate. Verifiable outcome: on Linux/CI the `FileModifyDate` branch fires for any PNG missing `DateTimeOriginal`/`CreateDate`; on macOS, screencaps still pick up the higher-precedence Apple value.
+2. If `is_apple_screen_capture` and `apple_content_creation_timestamp` are no longer reachable on non-macOS builds, gate them behind `#[cfg(target_os = "macos")]` to silence dead-code warnings without affecting macOS behavior. Verifiable outcome: `cargo build` and `cargo clippy` clean on both linux and macos targets.
+3. In `crates/xifty-cli/tests/cli_contract.rs`, add a new test (next to `apple_screenshot_png_uses_preserved_modified_time_when_birthtime_is_copy_time` at line 261) named `png_without_embedded_datetime_falls_back_to_filesystem_mtime`:
+   - Copy `fixtures/minimal/no_exif.png` to `std::env::temp_dir().join(...)` with a unique suffix (reuse `chrono_like_test_suffix`).
+   - Set a known mtime on the tmpfile using `filetime::set_file_mtime` if the crate is already a dev-dependency, otherwise via `std::fs::File::open(...).set_modified(SystemTime)` (Rust 1.75+, available with the workspace's edition 2024 toolchain). No shelling out to `touch` — the test must run portably on Linux CI.
+   - Call `xifty_cli::extract_path(temp_path, ViewMode::Normalized)`, normalize the result via the existing `normalized_map` helper, and assert `captured_at.value` and `created_at.value` equal the expected ISO-8601 UTC string derived from the mtime.
+   - Clean up the tmpfile with `let _ = fs::remove_file(temp_path);` like the existing test.
+   - This test is intentionally NOT gated on `target_os = "macos"` — it must pass on Linux CI and is the regression sentinel for this bug. Verifiable outcome: `cargo test -p xifty-cli png_without_embedded_datetime_falls_back_to_filesystem_mtime` passes on linux-x64.
+4. (Optional, if practical) Add an inline doc comment on `add_filesystem_timestamp_fallbacks` summarizing the two-tier behavior (universal mtime/ctime fallback; macOS Apple-screencap enrichment) so the next reader does not re-introduce the regression. Verifiable outcome: doc comment present.
+
+## Tests
+- New: `crates/xifty-cli/tests/cli_contract.rs::png_without_embedded_datetime_falls_back_to_filesystem_mtime` — portable Linux-runnable proof that the mtime fallback emits `captured_at` / `created_at`.
+- Existing: `crates/xifty-cli/tests/cli_contract.rs::apple_screenshot_png_uses_preserved_modified_time_when_birthtime_is_copy_time` (line 262) — must continue to pass on macOS unchanged; verifies the Apple enrichment branch is intact.
+- Existing snapshot suite (`extract_snapshot_*`) — must not regress; rerun with `cargo insta review` only if a deliberate diff is observed (none expected, since fixtures already have embedded datetimes or are not PNG).
+- Harness/regression against `prebuilds/linux-x64/@xifty+xifty.node`: out of scope for this PR. The Rust integration test in step 3 covers the same code path that gets compiled into the prebuild; once merged, the next prebuild release will carry the fix and the reporter can re-run their Lambda harness. No N-API harness change needed in this issue.
+
+## Validation
+Per `.loswf/config.yaml` `validate[]`:
+- `cargo fmt --all -- --check`
+- `cargo test --workspace --all-features`
+- `cargo test -p xifty-ffi --all-features`
+
+## Risks
+- **Test environment mtime resolution.** Some Linux filesystems (notably tmpfs with default `noatime`/coarse timestamps, or certain CI runners) round mtime to the second; the test must set a whole-second `SystemTime` to avoid sub-second drift in the formatted ISO string. Mitigation: choose a fixed Unix timestamp (e.g. `SystemTime::UNIX_EPOCH + Duration::from_secs(1_710_000_000)`) and format the expected string from the same value rather than reading it back.
+- **`set_modified` minimum Rust version.** `File::set_modified` requires Rust 1.75; the workspace is on edition 2024 (rustc ≥ 1.85), so this is safe. If the toolchain in CI is older than expected, fall back to the `filetime` crate (already commonly used in Rust workspaces) added under `[dev-dependencies]` of `xifty-cli`.
+- **Confidence-score change.** The current `filesystem_timestamp_entry` notes drive confidence/precedence in the normalize layer; restructuring the precedence inside `add_filesystem_timestamp_fallbacks` must keep the same `(tag_id, tag_name, note)` triples in the same order for the Apple branch — otherwise normalized output for existing macOS screenshots could shift confidence. Mitigation: preserve the current `or_else` order verbatim, only changing whether the Apple branch is attempted.
+- **Dead code on non-macOS.** Gating `is_apple_screen_capture` / `apple_content_creation_timestamp` with `#[cfg(target_os = "macos")]` removes them from Linux builds — confirm no other callsite references them (rg shows only the one callsite at line 649).
+- **Out-of-scope temptation.** The reporter asks about thresholds for "mtime too close to now" — explicitly NOT addressed here. There is no such threshold today and adding one would change behavior on macOS too. If desired, file a follow-up.
+


### PR DESCRIPTION
## Summary
- Restructure `add_filesystem_timestamp_fallbacks` so the universal `metadata.modified()` / `metadata.created()` branches run on every platform when a PNG has no embedded `DateTimeOriginal` / `CreateDate`. Previously the whole function early-returned unless `is_apple_screen_capture` (a macOS `xattr` shell-out) returned true, which is why the linux-x64 prebuild emitted no `captured_at` / `created_at` even with mtime set.
- Move the Apple `xattr`/`mdls`-driven `AppleContentCreationDate` enrichment into a `#[cfg(target_os = "macos")]` branch inside the function, preserving the existing precedence (`AppleContentCreationDate` -> `FileModifyDate` -> `FileCreateDate`) on macOS.
- Gate the Apple helpers (`is_apple_screen_capture`, `apple_content_creation_timestamp`, `parse_mdls_utc_timestamp`) and the `std::process::Command` import behind `#[cfg(target_os = "macos")]` so they don't compile on Linux.
- Add a portable regression test `png_without_embedded_datetime_falls_back_to_filesystem_mtime` (not gated on `target_os`) that copies `no_exif.png` to a tempfile, sets a known whole-second mtime via `File::set_modified`, and asserts `captured_at` / `created_at` are emitted with the expected ISO-8601 string.
- Three snapshots (`iptc.png`, `malformed_chunk.png`, `malformed_icc.png`) legitimately changed because those PNGs now surface the filesystem-derived timestamps. Extended `scrub_path` so filesystem-namespace fields render the absolute source path as a basename and the timestamp value as `<filesystem>`, keeping snapshots deterministic across hosts.

Closes #105

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --all-features` (123/123 in `xifty-cli`, full workspace green)
- [x] `cargo test -p xifty-ffi --all-features`
- [x] New `png_without_embedded_datetime_falls_back_to_filesystem_mtime` passes locally on macOS; runs without `target_os` gate so Linux CI will exercise it.
- [x] Existing `apple_screenshot_png_uses_preserved_modified_time_when_birthtime_is_copy_time` still passes on macOS.

## Notes / deviations from plan
- Plan said "no snapshot diffs expected." In practice three snapshots did change (legitimately) because PNGs without embedded capture timestamps now surface filesystem fallbacks, which also drops `no_metadata_entries` from the report view. Added `scrub_filesystem_fallback_fields` so the new snapshot shape is deterministic across machines (filesystem mtimes vary per checkout). The behavioral change is exactly what the bug fix intends.
- Also `#[cfg(target_os = "macos")]`-gated `parse_mdls_utc_timestamp` (only macOS callsite) and the `std::process::Command` import, beyond the two helpers the plan called out, to keep non-macOS builds clean.