### PR TITLE
feat: native Sony PROF/USMT UUID atom decoder for MP4/MOV (#118)

### DIFF
--- a/CAPABILITIES.json
+++ b/CAPABILITIES.json
@@ -254,6 +254,34 @@
         "Zoom",
         "SerialNumber"
       ]
+    },
+    "sony_video": {
+      "status": "bounded",
+      "supported_tags": [
+        "FileFunctionFlags",
+        "AudioTrackID",
+        "AudioCodec",
+        "AudioAvgBitrate",
+        "AudioMaxBitrate",
+        "AudioSampleRate",
+        "AudioChannels",
+        "VideoTrackID",
+        "VideoCodec",
+        "VideoAvgBitrate",
+        "VideoMaxBitrate",
+        "VideoAvgFrameRate",
+        "VideoMaxFrameRate",
+        "VideoSize",
+        "PixelAspectRatio",
+        "Title",
+        "ProductionDate",
+        "Software",
+        "Product",
+        "TrackProperty",
+        "TimeZone",
+        "ModifyDate"
+      ],
+      "notes": "Sony PROF (FPRF/APRF/VPRF) and USMT (MTDT) UUID atoms in MP4/MOV. Field maps reverse-engineered from ExifTool QuickTime.pm (`%QuickTime::FileProf`, `%AudioProf`, `%VideoProf`, `%MetaData`, `ProcessMetaData`). Phase 1 ship list; PRPF/AOLY are recognised structurally but not yet decoded."
     }
   },
   "containers": {
@@ -372,12 +400,14 @@
       "namespaces": {
         "quicktime": "bounded",
         "rtmd": "bounded",
-        "dji": "supported"
+        "dji": "supported",
+        "sony_video": "bounded"
       }
     },
     "mov": {
       "namespaces": {
-        "quicktime": "bounded"
+        "quicktime": "bounded",
+        "sony_video": "bounded"
       }
     },
     "m4a": {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,6 +831,7 @@ dependencies = [
  "xifty-meta-quicktime",
  "xifty-meta-rtmd",
  "xifty-meta-sony",
+ "xifty-meta-sony-video",
  "xifty-meta-vorbis-comment",
  "xifty-meta-xmp",
  "xifty-normalize",
@@ -1095,6 +1096,14 @@ name = "xifty-meta-sony"
 version = "0.1.11"
 dependencies = [
  "xifty-container-tiff",
+ "xifty-core",
+ "xifty-source",
+]
+
+[[package]]
+name = "xifty-meta-sony-video"
+version = "0.1.11"
+dependencies = [
  "xifty-core",
  "xifty-source",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
   "crates/xifty-meta-bwf",
   "crates/xifty-meta-ixml",
   "crates/xifty-meta-sony",
+  "crates/xifty-meta-sony-video",
   "crates/xifty-meta-nikon",
   "crates/xifty-meta-olympus",
   "crates/xifty-meta-canon",

--- a/crates/xifty-cli/Cargo.toml
+++ b/crates/xifty-cli/Cargo.toml
@@ -34,6 +34,7 @@ xifty-meta-apple = { path = "../xifty-meta-apple" }
 xifty-meta-bwf = { path = "../xifty-meta-bwf" }
 xifty-meta-ixml = { path = "../xifty-meta-ixml" }
 xifty-meta-sony = { path = "../xifty-meta-sony" }
+xifty-meta-sony-video = { path = "../xifty-meta-sony-video" }
 xifty-meta-nikon = { path = "../xifty-meta-nikon" }
 xifty-meta-olympus = { path = "../xifty-meta-olympus" }
 xifty-meta-canon = { path = "../xifty-meta-canon" }

--- a/crates/xifty-cli/src/lib.rs
+++ b/crates/xifty-cli/src/lib.rs
@@ -42,6 +42,7 @@ use xifty_meta_quicktime::{
 };
 use xifty_meta_rtmd::{RtmdPacket, decode_packet as decode_rtmd_packet};
 use xifty_meta_sony::decode_from_tiff as decode_sony_from_tiff;
+use xifty_meta_sony_video::{decode_prof, decode_usmt};
 use xifty_meta_vorbis_comment::{
     VorbisCommentPayload, decode_payload as decode_vorbis_comment_payload,
 };
@@ -1752,6 +1753,29 @@ fn isobmff_entries(
                 offset_start: payload.offset_start,
                 offset_end: payload.offset_end,
             }));
+        }
+    }
+
+    // Sony video user-data UUID atoms (PROF/USMT/...). The container parser
+    // recognises the full Sony-userdata family by usertype tail; here we
+    // dispatch the bounded ship-list (PROF + USMT). Unknown atom names are a
+    // silent no-op — the recognition layer already swallowed the
+    // uninterpreted info-issue, so adding a future decoder is a one-line
+    // change with no container-layer churn.
+    for payload in container.sony_video_atoms() {
+        let Some(payload_bytes) =
+            payload_slice(bytes, payload.data_offset, payload.data_length as usize)
+        else {
+            continue;
+        };
+        match payload.tag.as_deref() {
+            Some("PROF") => {
+                entries.extend(decode_prof(payload_bytes, payload.data_offset, format_name))
+            }
+            Some("USMT") => {
+                entries.extend(decode_usmt(payload_bytes, payload.data_offset, format_name))
+            }
+            _ => {}
         }
     }
 

--- a/crates/xifty-cli/tests/snapshots/cli_contract__extract_real_camera_mp4_interpreted.snap
+++ b/crates/xifty-cli/tests/snapshots/cli_contract__extract_real_camera_mp4_interpreted.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/xifty-cli/tests/cli_contract.rs
-assertion_line: 793
+assertion_line: 1199
 expression: output
 ---
 {
@@ -275,6 +275,297 @@ expression: output
         "value": {
           "kind": "string",
           "value": "rec709-xvycc"
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 68,
+          "path": "moov/uuid/PROF/FPRF"
+        },
+        "tag_id": "PROF/FPRF",
+        "tag_name": "FileFunctionFlags",
+        "value": {
+          "kind": "integer",
+          "value": 536870912
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 88,
+          "path": "moov/uuid/PROF/APRF"
+        },
+        "tag_id": "PROF/APRF/1",
+        "tag_name": "AudioTrackID",
+        "value": {
+          "kind": "integer",
+          "value": 2
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 88,
+          "path": "moov/uuid/PROF/APRF"
+        },
+        "tag_id": "PROF/APRF/2",
+        "tag_name": "AudioCodec",
+        "value": {
+          "kind": "string",
+          "value": "twos"
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 88,
+          "path": "moov/uuid/PROF/APRF"
+        },
+        "tag_id": "PROF/APRF/5",
+        "tag_name": "AudioAvgBitrate",
+        "value": {
+          "kind": "integer",
+          "value": 1536000
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 88,
+          "path": "moov/uuid/PROF/APRF"
+        },
+        "tag_id": "PROF/APRF/6",
+        "tag_name": "AudioMaxBitrate",
+        "value": {
+          "kind": "integer",
+          "value": 1536000
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 88,
+          "path": "moov/uuid/PROF/APRF"
+        },
+        "tag_id": "PROF/APRF/7",
+        "tag_name": "AudioSampleRate",
+        "value": {
+          "kind": "integer",
+          "value": 48000
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 88,
+          "path": "moov/uuid/PROF/APRF"
+        },
+        "tag_id": "PROF/APRF/8",
+        "tag_name": "AudioChannels",
+        "value": {
+          "kind": "integer",
+          "value": 2
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 132,
+          "path": "moov/uuid/PROF/VPRF"
+        },
+        "tag_id": "PROF/VPRF/1",
+        "tag_name": "VideoTrackID",
+        "value": {
+          "kind": "integer",
+          "value": 1
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 132,
+          "path": "moov/uuid/PROF/VPRF"
+        },
+        "tag_id": "PROF/VPRF/2",
+        "tag_name": "VideoCodec",
+        "value": {
+          "kind": "string",
+          "value": "avc1"
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 132,
+          "path": "moov/uuid/PROF/VPRF"
+        },
+        "tag_id": "PROF/VPRF/5",
+        "tag_name": "VideoAvgBitrate",
+        "value": {
+          "kind": "integer",
+          "value": 100000000
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 132,
+          "path": "moov/uuid/PROF/VPRF"
+        },
+        "tag_id": "PROF/VPRF/6",
+        "tag_name": "VideoMaxBitrate",
+        "value": {
+          "kind": "integer",
+          "value": 100000000
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 132,
+          "path": "moov/uuid/PROF/VPRF"
+        },
+        "tag_id": "PROF/VPRF/7",
+        "tag_name": "VideoAvgFrameRate",
+        "value": {
+          "kind": "float",
+          "value": 23.97601318359375
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 132,
+          "path": "moov/uuid/PROF/VPRF"
+        },
+        "tag_id": "PROF/VPRF/8",
+        "tag_name": "VideoMaxFrameRate",
+        "value": {
+          "kind": "float",
+          "value": 23.97601318359375
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 132,
+          "path": "moov/uuid/PROF/VPRF"
+        },
+        "tag_id": "PROF/VPRF/9",
+        "tag_name": "VideoSize",
+        "value": {
+          "kind": "dimensions",
+          "value": {
+            "height": 2160,
+            "width": 3840
+          }
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 132,
+          "path": "moov/uuid/PROF/VPRF"
+        },
+        "tag_id": "PROF/VPRF/10",
+        "tag_name": "PixelAspectRatio",
+        "value": {
+          "kind": "rational",
+          "value": {
+            "denominator": 1,
+            "numerator": 1
+          }
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 25167328,
+          "path": "moov/uuid/USMT/MTDT"
+        },
+        "tag_id": "USMT/MTDT/0x000a",
+        "tag_name": "TrackProperty",
+        "value": {
+          "kind": "string",
+          "value": "flags=1 attr=0 priority=0"
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 25167844,
+          "path": "moov/uuid/USMT/MTDT"
+        },
+        "tag_id": "USMT/MTDT/0x000a",
+        "tag_name": "TrackProperty",
+        "value": {
+          "kind": "string",
+          "value": "flags=1 attr=0 priority=0"
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 25168353,
+          "path": "moov/uuid/USMT/MTDT"
+        },
+        "tag_id": "USMT/MTDT/0x000a",
+        "tag_name": "TrackProperty",
+        "value": {
+          "kind": "string",
+          "value": "flags=16 attr=0 priority=0"
+        }
+      },
+      {
+        "namespace": "sony_video",
+        "provenance": {
+          "container": "mp4",
+          "namespace": "sony_video",
+          "offset_start": 25168405,
+          "path": "moov/uuid/USMT/MTDT"
+        },
+        "tag_id": "USMT/MTDT/0x000b",
+        "tag_name": "TimeZone",
+        "value": {
+          "kind": "integer",
+          "value": -480
         }
       },
       {

--- a/crates/xifty-container-isobmff/src/lib.rs
+++ b/crates/xifty-container-isobmff/src/lib.rs
@@ -28,9 +28,20 @@ const CANON_CMT_UUID: [u8; 16] = [
     0x85, 0xc0, 0xb6, 0x87, 0x82, 0x0f, 0x11, 0xe0, 0x81, 0x11, 0xf4, 0xce, 0x46, 0x2b, 0x6a, 0x48,
 ];
 
+/// Sony "User Data Atom UUID" tail. The full 16-byte usertype is
+/// `<atom-name (4 ASCII bytes)> + SONY_USERDATA_UUID_TAIL`. Atom names seen
+/// in the wild include `PROF`, `USMT`, `PRPF`, `AOLY`, `MTDT`. Source:
+/// ExifTool `lib/Image/ExifTool/QuickTime.pm` (`UUID-PROF` at line ~711-718,
+/// `UUID-USMT` at line ~1223-1231 and ~1449-1457).
+const SONY_USERDATA_UUID_TAIL: [u8; 12] = [
+    0x21, 0xd2, 0x4f, 0xce, 0xbb, 0x88, 0x69, 0x5c, 0xfa, 0xc9, 0xc7, 0x40,
+];
+
 /// Recognised payload `kind` discriminants:
 /// `"exif"`, `"xmp"`, `"icc"`, `"iptc"`, `"quicktime"`, `"quicktime-udta"`,
-/// `"itunes"`, and `"canon-cmt"` (Canon CR3 CMT2/CMT3/CMT4 maker-note IFDs).
+/// `"itunes"`, `"canon-cmt"` (Canon CR3 CMT2/CMT3/CMT4 maker-note IFDs), and
+/// `"sony-video-atom"` (Sony PROF/USMT/etc. user-data UUID atoms — `tag`
+/// holds the 4-character ASCII atom name from the usertype prefix).
 #[derive(Debug, Clone)]
 pub struct IsobmffPayload {
     pub kind: &'static str,
@@ -151,6 +162,17 @@ impl IsobmffContainer {
         self.payloads
             .iter()
             .filter(|payload| payload.kind == "canon-cmt")
+    }
+
+    /// Sony video user-data atoms surfaced from `uuid` boxes whose 16-byte
+    /// usertype matches `<atom-name (4 ASCII)> + SONY_USERDATA_UUID_TAIL`.
+    /// `payload.tag` holds the atom name (`"PROF"`, `"USMT"`, `"PRPF"`, ...).
+    /// `payload.data_offset`/`data_length` cover the bytes that follow the
+    /// 16-byte usertype — i.e. the slice that decoders consume directly.
+    pub fn sony_video_atoms(&self) -> impl Iterator<Item = &IsobmffPayload> {
+        self.payloads
+            .iter()
+            .filter(|payload| payload.kind == "sony-video-atom")
     }
 
     pub fn is_heif_still_image(&self) -> bool {
@@ -1843,10 +1865,36 @@ fn parse_uuid(
     usertype.copy_from_slice(usertype_slice);
     let inner_start = parsed.data_offset + 16;
     if usertype != CANON_CMT_UUID {
+        // Sony "User Data Atom UUID family": usertype tail bytes 4..16 match
+        // SONY_USERDATA_UUID_TAIL and bytes 0..4 carry the atom name in
+        // ASCII (PROF/USMT/PRPF/AOLY/MTDT/...). Surface as a single payload
+        // per atom; downstream `xifty-meta-sony-video` dispatches by tag.
+        if usertype[4..16] == SONY_USERDATA_UUID_TAIL
+            && usertype[0..4]
+                .iter()
+                .all(|b| b.is_ascii_alphanumeric() || *b == b' ')
+        {
+            let name_bytes = [usertype[0], usertype[1], usertype[2], usertype[3]];
+            let atom_name = fourcc(name_bytes);
+            payloads.push(IsobmffPayload {
+                kind: "sony-video-atom",
+                tag: Some(atom_name.clone()),
+                offset_start: cursor.absolute_offset(parsed.start),
+                offset_end: cursor.absolute_offset(parsed.end),
+                data_offset: cursor.absolute_offset(inner_start),
+                data_length: (parsed.end - inner_start) as u64,
+                path: format!("{}/{}", parsed.path, atom_name),
+            });
+            return;
+        }
+        let usertype_hex = usertype
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<String>();
         issues.push(Issue {
             severity: Severity::Info,
             code: "isobmff_structure_recognized_uninterpreted".into(),
-            message: "recognized uuid box but the usertype is not handled".into(),
+            message: format!("recognized uuid box but the usertype {usertype_hex} is not handled"),
             offset: Some(cursor.absolute_offset(parsed.start)),
             context: Some(parsed.path.clone()),
         });
@@ -2212,9 +2260,56 @@ mod tests {
         let parsed = parse_bytes(&bytes, 0).unwrap();
         assert_eq!(parsed.canon_cmt_payloads().count(), 0);
         assert_eq!(parsed.exif_payloads().count(), 0);
-        assert!(parsed.issues.iter().any(|issue| issue.code
-            == "isobmff_structure_recognized_uninterpreted"
-            && issue.context.as_deref() == Some("moov/uuid")));
+        assert_eq!(parsed.sony_video_atoms().count(), 0);
+        let issue = parsed
+            .issues
+            .iter()
+            .find(|issue| {
+                issue.code == "isobmff_structure_recognized_uninterpreted"
+                    && issue.context.as_deref() == Some("moov/uuid")
+            })
+            .expect("uninterpreted-uuid issue");
+        // Issue body now carries the lowercase-hex usertype so future unknown
+        // families are actionable from the issue stream alone.
+        assert!(
+            issue.message.contains("00000000000000000000000000000000"),
+            "expected hex in {}",
+            issue.message,
+        );
+    }
+
+    #[test]
+    fn recognizes_sony_userdata_uuid_family() {
+        // Synthetic Sony-PROF UUID box. Usertype = "PROF" + Sony tail; payload
+        // body is opaque (the decoder lives in xifty-meta-sony-video).
+        let mut uuid_payload = Vec::new();
+        uuid_payload.extend_from_slice(b"PROF");
+        uuid_payload.extend_from_slice(&[
+            0x21, 0xd2, 0x4f, 0xce, 0xbb, 0x88, 0x69, 0x5c, 0xfa, 0xc9, 0xc7, 0x40,
+        ]);
+        uuid_payload.extend_from_slice(b"opaque-prof-bytes");
+        let uuid = boxed(b"uuid", &uuid_payload);
+        let bytes = [boxed(b"ftyp", b"isom\0\0\0\0mp42"), boxed(b"moov", &uuid)].concat();
+
+        let parsed = parse_bytes(&bytes, 0).unwrap();
+        let atoms: Vec<_> = parsed.sony_video_atoms().collect();
+        assert_eq!(atoms.len(), 1, "expected one sony-video-atom payload");
+        let atom = atoms[0];
+        assert_eq!(atom.tag.as_deref(), Some("PROF"));
+        assert_eq!(atom.kind, "sony-video-atom");
+        // data_offset/data_length must skip the 16-byte usertype.
+        assert_eq!(atom.data_length, b"opaque-prof-bytes".len() as u64);
+        // No uninterpreted info-issue for a known Sony family.
+        assert!(
+            !parsed.issues.iter().any(|issue| issue.code
+                == "isobmff_structure_recognized_uninterpreted"
+                && issue
+                    .context
+                    .as_deref()
+                    .is_some_and(|ctx| ctx.contains("uuid"))),
+            "Sony-PROF UUID should not produce an uninterpreted info issue: {:?}",
+            parsed.issues,
+        );
     }
 
     #[test]

--- a/crates/xifty-meta-sony-video/Cargo.toml
+++ b/crates/xifty-meta-sony-video/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "xifty-meta-sony-video"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+xifty-core = { path = "../xifty-core" }
+xifty-source = { path = "../xifty-source" }

--- a/crates/xifty-meta-sony-video/src/lib.rs
+++ b/crates/xifty-meta-sony-video/src/lib.rs
@@ -1,0 +1,42 @@
+//! Sony video metadata interpreter (`namespace = "sony_video"`).
+//!
+//! Decodes Sony's `PROF` and `USMT` UUID atoms found in MP4/MOV files
+//! produced by Sony pro/prosumer video cameras (FX-series, A7-series video,
+//! A1). The Sony "User Data Atom UUID family" uses a 16-byte usertype where
+//! bytes 0..4 are the atom name in ASCII (PROF, USMT, PRPF, ...) and bytes
+//! 4..16 are the constant tail
+//! `21 d2 4f ce bb 88 69 5c fa c9 c7 40`.
+//!
+//! Reverse-engineered from ExifTool's `lib/Image/ExifTool/QuickTime.pm`
+//! (`UUID-PROF`/`UUID-USMT` dispatch, `%Profile`, `%FileProf`, `%AudioProf`,
+//! `%VideoProf`, `%UserMedia`, `%MetaData`, and `ProcessMetaData`). ExifTool
+//! is reference material only — read to understand, port to Rust, ship Rust.
+//! Nothing from ExifTool ships in the artifact.
+//!
+//! ## Phase 1 bounded ship list
+//!
+//! **PROF** — sub-boxes dispatched: `FPRF`, `APRF`, `VPRF`. See `prof.rs`
+//! module-level docs for per-tag citations.
+//!
+//! **USMT** — only `MTDT` sub-boxes dispatched (per `%QuickTime::UserMedia`
+//! at `QuickTime.pm:2589-2597`). MTDT records emit the well-attested subset
+//! `Title / ProductionDate / Software / Product / TrackProperty / TimeZone /
+//! ModifyDate` per `%QuickTime::MetaData` (`QuickTime.pm:2599-2658`).
+//!
+//! `PRPF` and `AOLY` (and other Sony-family atoms) are recognised by the
+//! container parser as `kind = "sony-video-atom"` but are deferred for
+//! Phase 2 — the dispatcher silently no-ops on unknown tags so future
+//! decoders can be added without touching the container layer.
+
+mod prof;
+mod usmt;
+
+pub use prof::decode_prof;
+pub use usmt::decode_usmt;
+
+/// FourCC names of `uuid` atom families this crate currently dispatches to a
+/// real decoder. Reflects the Phase 1 bounded ship list. Container-level
+/// recognition (in `xifty-container-isobmff::parse_uuid`) covers a wider set
+/// (PROF/USMT/PRPF/AOLY/MTDT-as-uuid/etc.); this list narrows that to the
+/// subset that has a working Rust decoder behind it.
+pub const SUPPORTED_USERTYPES: &[&str] = &["PROF", "USMT"];

--- a/crates/xifty-meta-sony-video/src/prof.rs
+++ b/crates/xifty-meta-sony-video/src/prof.rs
@@ -1,0 +1,394 @@
+//! PROF (Picture Profile) UUID atom decoder.
+//!
+//! ## Wire format (per ExifTool `lib/Image/ExifTool/QuickTime.pm`)
+//!
+//! - The Sony `PROF` UUID box wraps a 16-byte usertype
+//!   `50 52 4f 46 21 d2 4f ce bb 88 69 5c fa c9 c7 40` (PROF + Sony tail).
+//!   See `QuickTime.pm` line ~711-718 (`UUID-PROF` dispatch:
+//!   `Start => 24, # uid(16) + version(1) + flags(3) + count(4)`).
+//! - After the 16-byte usertype the payload is a "profile container":
+//!   `version(1) + flags(3) + count(4) + N × (size(4) + FourCC(4) + body)`.
+//!   The container is dispatched via `%Image::ExifTool::QuickTime::Profile`
+//!   (`QuickTime.pm` line ~2668-2692). Recognised sub-box FourCCs are
+//!   `FPRF` (FileGlobalProfile), `APRF` (AudioProfile), `VPRF` (VideoProfile).
+//! - Each sub-box body is a `ProcessBinaryData` blob with `FORMAT => 'int32u'`
+//!   (big-endian); fields are addressed by 32-bit-word index. Tables:
+//!   - `FileProf`  — `QuickTime.pm` line ~2694-2709.
+//!   - `AudioProf` — `QuickTime.pm` line ~2711-2747.
+//!   - `VideoProf` — `QuickTime.pm` line ~2749-2804.
+//!
+//! Reference material only — read to understand, port to Rust, ship Rust.
+//! Nothing from ExifTool ships in the artifact.
+
+use xifty_core::{MetadataEntry, Provenance, TypedValue};
+use xifty_source::{Cursor, Endian};
+
+/// Decode the inner bytes of a Sony `PROF` UUID atom (post-usertype slice).
+///
+/// `bytes` must contain the bytes that follow the 16-byte usertype — i.e.
+/// `version(1) + flags(3) + count(4) + sub-boxes...`. `base_offset` is the
+/// absolute offset within the source where `bytes` begins; provenance is
+/// recorded against this base.
+pub fn decode_prof(bytes: &[u8], base_offset: u64, container_name: &str) -> Vec<MetadataEntry> {
+    let mut out = Vec::new();
+    if bytes.len() < 8 {
+        return out;
+    }
+    let cursor = Cursor::new(bytes, base_offset);
+    let Ok(count) = cursor.read_u32(4, Endian::Big) else {
+        return out;
+    };
+    let mut pos = 8usize;
+    let mut emitted = 0u32;
+    while emitted < count && pos + 8 <= bytes.len() {
+        let Ok(box_size) = cursor.read_u32(pos, Endian::Big) else {
+            return out;
+        };
+        let box_size = box_size as usize;
+        if box_size < 8 || pos + box_size > bytes.len() {
+            return out;
+        }
+        let fourcc: [u8; 4] = match bytes.get(pos + 4..pos + 8) {
+            Some(slice) => [slice[0], slice[1], slice[2], slice[3]],
+            None => return out,
+        };
+        let body_start = pos + 8;
+        let body_end = pos + box_size;
+        let body = &bytes[body_start..body_end];
+        let body_offset = base_offset + body_start as u64;
+        match &fourcc {
+            b"FPRF" => decode_fprf(body, body_offset, container_name, &mut out),
+            b"APRF" => decode_aprf(body, body_offset, container_name, &mut out),
+            b"VPRF" => decode_vprf(body, body_offset, container_name, &mut out),
+            _ => {
+                // Unknown sub-box (e.g. PREX, OLYM): skip silently. ExifTool
+                // routes unknowns through generic ProcessBinaryData; we drop
+                // them here per the bounded-ship policy.
+            }
+        }
+        pos += box_size;
+        emitted += 1;
+    }
+    out
+}
+
+/// FPRF — FileGlobalProfile. Per `QuickTime.pm:2694-2709`.
+/// Word 0: FileProfileVersion (Unknown, skipped).
+/// Word 1: FileFunctionFlags (bitmask).
+fn decode_fprf(body: &[u8], base_offset: u64, container: &str, out: &mut Vec<MetadataEntry>) {
+    let cursor = Cursor::new(body, base_offset);
+    if let Ok(flags) = cursor.read_u32(4, Endian::Big) {
+        out.push(entry(
+            container,
+            "PROF/FPRF",
+            "FileFunctionFlags",
+            TypedValue::Integer(flags as i64),
+            "moov/uuid/PROF/FPRF",
+            base_offset,
+        ));
+    }
+}
+
+/// APRF — AudioProfile. Per `QuickTime.pm:2711-2747`.
+fn decode_aprf(body: &[u8], base_offset: u64, container: &str, out: &mut Vec<MetadataEntry>) {
+    let cursor = Cursor::new(body, base_offset);
+    // Word 1: AudioTrackID
+    if let Ok(value) = cursor.read_u32(4, Endian::Big) {
+        out.push(entry(
+            container,
+            "PROF/APRF/1",
+            "AudioTrackID",
+            TypedValue::Integer(value as i64),
+            "moov/uuid/PROF/APRF",
+            base_offset,
+        ));
+    }
+    // Word 2: AudioCodec (4-byte FourCC, ASCII)
+    if let Some(slice) = body.get(8..12)
+        && let Some(codec) = ascii_fourcc(slice)
+    {
+        out.push(entry(
+            container,
+            "PROF/APRF/2",
+            "AudioCodec",
+            TypedValue::String(codec),
+            "moov/uuid/PROF/APRF",
+            base_offset,
+        ));
+    }
+    // Word 5: AudioAvgBitrate (kbps, * 1000 in ExifTool ValueConv).
+    if let Ok(value) = cursor.read_u32(20, Endian::Big) {
+        out.push(entry(
+            container,
+            "PROF/APRF/5",
+            "AudioAvgBitrate",
+            TypedValue::Integer((value as i64) * 1000),
+            "moov/uuid/PROF/APRF",
+            base_offset,
+        ));
+    }
+    // Word 6: AudioMaxBitrate (kbps).
+    if let Ok(value) = cursor.read_u32(24, Endian::Big) {
+        out.push(entry(
+            container,
+            "PROF/APRF/6",
+            "AudioMaxBitrate",
+            TypedValue::Integer((value as i64) * 1000),
+            "moov/uuid/PROF/APRF",
+            base_offset,
+        ));
+    }
+    // Word 7: AudioSampleRate
+    if let Ok(value) = cursor.read_u32(28, Endian::Big) {
+        out.push(entry(
+            container,
+            "PROF/APRF/7",
+            "AudioSampleRate",
+            TypedValue::Integer(value as i64),
+            "moov/uuid/PROF/APRF",
+            base_offset,
+        ));
+    }
+    // Word 8: AudioChannels (high 16 bits of a 32-bit slot in some captures —
+    // ExifTool reads as int32u; we mirror that.)
+    if let Ok(value) = cursor.read_u32(32, Endian::Big) {
+        out.push(entry(
+            container,
+            "PROF/APRF/8",
+            "AudioChannels",
+            TypedValue::Integer(value as i64),
+            "moov/uuid/PROF/APRF",
+            base_offset,
+        ));
+    }
+}
+
+/// VPRF — VideoProfile. Per `QuickTime.pm:2749-2804`.
+fn decode_vprf(body: &[u8], base_offset: u64, container: &str, out: &mut Vec<MetadataEntry>) {
+    let cursor = Cursor::new(body, base_offset);
+    // Word 1: VideoTrackID
+    if let Ok(value) = cursor.read_u32(4, Endian::Big) {
+        out.push(entry(
+            container,
+            "PROF/VPRF/1",
+            "VideoTrackID",
+            TypedValue::Integer(value as i64),
+            "moov/uuid/PROF/VPRF",
+            base_offset,
+        ));
+    }
+    // Word 2: VideoCodec (4-byte FourCC).
+    if let Some(slice) = body.get(8..12)
+        && let Some(codec) = ascii_fourcc(slice)
+    {
+        out.push(entry(
+            container,
+            "PROF/VPRF/2",
+            "VideoCodec",
+            TypedValue::String(codec),
+            "moov/uuid/PROF/VPRF",
+            base_offset,
+        ));
+    }
+    // Word 5: VideoAvgBitrate (kbps).
+    if let Ok(value) = cursor.read_u32(20, Endian::Big) {
+        out.push(entry(
+            container,
+            "PROF/VPRF/5",
+            "VideoAvgBitrate",
+            TypedValue::Integer((value as i64) * 1000),
+            "moov/uuid/PROF/VPRF",
+            base_offset,
+        ));
+    }
+    // Word 6: VideoMaxBitrate (kbps).
+    if let Ok(value) = cursor.read_u32(24, Endian::Big) {
+        out.push(entry(
+            container,
+            "PROF/VPRF/6",
+            "VideoMaxBitrate",
+            TypedValue::Integer((value as i64) * 1000),
+            "moov/uuid/PROF/VPRF",
+            base_offset,
+        ));
+    }
+    // Word 7: VideoAvgFrameRate (16.16 fixed-point).
+    if let Ok(value) = cursor.read_u32(28, Endian::Big) {
+        let fps = (value as f64) / 65536.0;
+        out.push(entry(
+            container,
+            "PROF/VPRF/7",
+            "VideoAvgFrameRate",
+            TypedValue::Float(fps),
+            "moov/uuid/PROF/VPRF",
+            base_offset,
+        ));
+    }
+    // Word 8: VideoMaxFrameRate (16.16 fixed-point).
+    if let Ok(value) = cursor.read_u32(32, Endian::Big) {
+        let fps = (value as f64) / 65536.0;
+        out.push(entry(
+            container,
+            "PROF/VPRF/8",
+            "VideoMaxFrameRate",
+            TypedValue::Float(fps),
+            "moov/uuid/PROF/VPRF",
+            base_offset,
+        ));
+    }
+    // Word 9: VideoSize — int16u[2] (width, height).
+    if let (Ok(width), Ok(height)) = (
+        cursor.read_u16(36, Endian::Big),
+        cursor.read_u16(38, Endian::Big),
+    ) {
+        out.push(entry(
+            container,
+            "PROF/VPRF/9",
+            "VideoSize",
+            TypedValue::Dimensions {
+                width: width as u32,
+                height: height as u32,
+            },
+            "moov/uuid/PROF/VPRF",
+            base_offset,
+        ));
+    }
+    // Word 10: PixelAspectRatio — int16u[2].
+    if let (Ok(num), Ok(den)) = (
+        cursor.read_u16(40, Endian::Big),
+        cursor.read_u16(42, Endian::Big),
+    ) {
+        out.push(entry(
+            container,
+            "PROF/VPRF/10",
+            "PixelAspectRatio",
+            TypedValue::Rational {
+                numerator: num as i64,
+                denominator: den as i64,
+            },
+            "moov/uuid/PROF/VPRF",
+            base_offset,
+        ));
+    }
+}
+
+fn ascii_fourcc(slice: &[u8]) -> Option<String> {
+    let trimmed: Vec<u8> = slice.iter().take_while(|b| **b != 0).copied().collect();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if !trimmed.iter().all(|b| (0x20..=0x7e).contains(b) || *b == 0) {
+        return None;
+    }
+    String::from_utf8(trimmed).ok()
+}
+
+fn entry(
+    container: &str,
+    tag_id: &str,
+    tag_name: &str,
+    value: TypedValue,
+    path: &str,
+    offset_start: u64,
+) -> MetadataEntry {
+    MetadataEntry {
+        namespace: "sony_video".into(),
+        tag_id: tag_id.into(),
+        tag_name: tag_name.into(),
+        value,
+        provenance: Provenance {
+            container: container.into(),
+            namespace: "sony_video".into(),
+            path: Some(path.into()),
+            offset_start: Some(offset_start),
+            offset_end: None,
+            notes: Vec::new(),
+        },
+        notes: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Real bytes captured from `fixtures/local/C0242.MP4` (Sony FX-series),
+    /// PROF UUID at file offset 28. After stripping the 16-byte usertype this
+    /// is the exact payload (124 bytes). Used as the canonical test vector
+    /// since synthetic byte buffers cannot reliably exercise the wire format.
+    fn c0242_prof_inner() -> Vec<u8> {
+        let hex = "000000000000000300000014465052460000000020000000000000000000002c\
+                   41505246000000000000000274776f730000000000000000000006000000060\
+                   00000bb800000000200000034565052460000000000000001617663310164003\
+                   30003000200018\
+                   6a0000186a00017f9dc0017f9dc0f00087000010001";
+        // The hex above was line-folded for readability; rebuild without nl.
+        hex.chars()
+            .filter(|c| c.is_ascii_hexdigit())
+            .collect::<String>()
+            .as_bytes()
+            .chunks(2)
+            .map(|c| u8::from_str_radix(std::str::from_utf8(c).unwrap(), 16).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn decodes_real_c0242_prof_payload() {
+        let bytes = c0242_prof_inner();
+        let entries = decode_prof(&bytes, 0, "mp4");
+        // VPRF + APRF + FPRF should each contribute fields.
+        let names: Vec<_> = entries.iter().map(|e| e.tag_name.as_str()).collect();
+        assert!(names.contains(&"FileFunctionFlags"), "names={names:?}");
+        assert!(names.contains(&"AudioCodec"), "names={names:?}");
+        assert!(names.contains(&"VideoCodec"), "names={names:?}");
+        assert!(names.contains(&"VideoSize"), "names={names:?}");
+
+        let codec = entries
+            .iter()
+            .find(|e| e.tag_name == "VideoCodec")
+            .expect("VideoCodec entry");
+        assert!(matches!(&codec.value, TypedValue::String(s) if s == "avc1"));
+
+        let audio_codec = entries
+            .iter()
+            .find(|e| e.tag_name == "AudioCodec")
+            .expect("AudioCodec entry");
+        assert!(matches!(&audio_codec.value, TypedValue::String(s) if s == "twos"));
+
+        let size = entries
+            .iter()
+            .find(|e| e.tag_name == "VideoSize")
+            .expect("VideoSize entry");
+        match &size.value {
+            TypedValue::Dimensions { width, height } => {
+                assert_eq!(*width, 3840);
+                assert_eq!(*height, 2160);
+            }
+            other => panic!("expected Dimensions, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_input_returns_no_entries() {
+        assert!(decode_prof(&[], 0, "mp4").is_empty());
+        assert!(decode_prof(&[0u8; 4], 0, "mp4").is_empty());
+    }
+
+    #[test]
+    fn provenance_uses_supplied_container_and_namespace() {
+        let bytes = c0242_prof_inner();
+        let entries = decode_prof(&bytes, 100, "mov");
+        let any = entries.first().expect("at least one entry");
+        assert_eq!(any.namespace, "sony_video");
+        assert_eq!(any.provenance.container, "mov");
+        assert_eq!(any.provenance.namespace, "sony_video");
+        assert!(
+            any.provenance
+                .path
+                .as_ref()
+                .unwrap()
+                .starts_with("moov/uuid/PROF/")
+        );
+        assert!(any.provenance.offset_start.unwrap() >= 100);
+    }
+}

--- a/crates/xifty-meta-sony-video/src/usmt.rs
+++ b/crates/xifty-meta-sony-video/src/usmt.rs
@@ -1,0 +1,308 @@
+//! USMT (User SMPTE-style metadata) UUID atom decoder.
+//!
+//! ## Wire format (per ExifTool `lib/Image/ExifTool/QuickTime.pm`)
+//!
+//! - The Sony `USMT` UUID box wraps a 16-byte usertype
+//!   `55 53 4d 54 21 d2 4f ce bb 88 69 5c fa c9 c7 40` (USMT + Sony tail).
+//!   See `QuickTime.pm` line ~1223-1231 (`UUID-USMT` dispatch:
+//!   `Start => 16` — i.e. no header bytes between usertype and sub-boxes).
+//! - The payload (post-usertype) is a sequence of standard ISOBMFF boxes
+//!   (`size(4) + FourCC(4) + body`). The only known dispatched FourCC is
+//!   `MTDT` (MetaData) — see `%QuickTime::UserMedia` at `QuickTime.pm:2589-2597`.
+//! - Each `MTDT` body is parsed by `ProcessMetaData` (`QuickTime.pm:9573-9619`):
+//!   `count(2 BE) + N × { size(2) + tag(4) + lang(2) + enc(2) + value(size-10) }`.
+//! - Tag dispatch is `%QuickTime::MetaData` (`QuickTime.pm:2599-2658`):
+//!   - `0x01` Title          (string)
+//!   - `0x03` ProductionDate (string `YYYY/mm/dd HH:MM:SS`)
+//!   - `0x04` Software       (string)
+//!   - `0x05` Product        (string)
+//!   - `0x0a` TrackProperty  (struct `Nnn` → flags(4) + attr(2) + priority(2))
+//!   - `0x0b` TimeZone       (i16 BE, minutes from UTC)
+//!   - `0x0c` ModifyDate     (string `YYYY/mm/dd HH:MM:SS`)
+//! - Encoding word: `0` = 8-bit (Latin-1/ASCII), `1` = UTF-16 BE.
+//!
+//! Reference material only — read to understand, port to Rust, ship Rust.
+//! Nothing from ExifTool ships in the artifact.
+
+use xifty_core::{MetadataEntry, Provenance, TypedValue};
+use xifty_source::{Cursor, Endian};
+
+/// Decode the inner bytes of a Sony `USMT` UUID atom (post-usertype slice).
+///
+/// `bytes` is the box payload that follows the 16-byte usertype: a tree of
+/// ISOBMFF sub-boxes containing zero or more `MTDT` MetaData blobs.
+pub fn decode_usmt(bytes: &[u8], base_offset: u64, container_name: &str) -> Vec<MetadataEntry> {
+    let mut out = Vec::new();
+    let cursor = Cursor::new(bytes, base_offset);
+    let mut pos = 0usize;
+    while pos + 8 <= bytes.len() {
+        let Ok(box_size) = cursor.read_u32(pos, Endian::Big) else {
+            return out;
+        };
+        let box_size = box_size as usize;
+        if box_size < 8 || pos + box_size > bytes.len() {
+            return out;
+        }
+        let fourcc: [u8; 4] = match bytes.get(pos + 4..pos + 8) {
+            Some(slice) => [slice[0], slice[1], slice[2], slice[3]],
+            None => return out,
+        };
+        let body_start = pos + 8;
+        let body_end = pos + box_size;
+        if &fourcc == b"MTDT" {
+            decode_mtdt(
+                &bytes[body_start..body_end],
+                base_offset + body_start as u64,
+                container_name,
+                &mut out,
+            );
+        }
+        pos += box_size;
+    }
+    out
+}
+
+/// Walk one MTDT body. Per `ProcessMetaData` (`QuickTime.pm:9573-9619`).
+fn decode_mtdt(body: &[u8], base_offset: u64, container: &str, out: &mut Vec<MetadataEntry>) {
+    if body.len() < 2 {
+        return;
+    }
+    let cursor = Cursor::new(body, base_offset);
+    let Ok(count) = cursor.read_u16(0, Endian::Big) else {
+        return;
+    };
+    let mut pos = 2usize;
+    for _ in 0..count {
+        if pos + 10 > body.len() {
+            return;
+        }
+        let Ok(size) = cursor.read_u16(pos, Endian::Big) else {
+            return;
+        };
+        let size = size as usize;
+        if size < 10 || pos + size > body.len() {
+            return;
+        }
+        let Ok(tag) = cursor.read_u32(pos + 2, Endian::Big) else {
+            return;
+        };
+        // pos+6..pos+8 lang (UnpackLang in ExifTool); pos+8..pos+10 encoding.
+        let Ok(enc) = cursor.read_u16(pos + 8, Endian::Big) else {
+            return;
+        };
+        let value_bytes = &body[pos + 10..pos + size];
+        if let Some(entry) =
+            decode_record(tag, enc, value_bytes, container, base_offset + pos as u64)
+        {
+            out.push(entry);
+        }
+        pos += size;
+    }
+}
+
+fn decode_record(
+    tag: u32,
+    enc: u16,
+    value: &[u8],
+    container: &str,
+    offset_start: u64,
+) -> Option<MetadataEntry> {
+    let (tag_name, typed) = match tag {
+        // Per QuickTime.pm:2604 — Title (string).
+        0x01 => ("Title", string_value(enc, value)?),
+        // Per QuickTime.pm:2605-2617 — ProductionDate (YYYY/mm/dd HH:MM:SS).
+        0x03 => ("ProductionDate", string_value(enc, value)?),
+        // Per QuickTime.pm:2618 — Software (string).
+        0x04 => ("Software", string_value(enc, value)?),
+        // Per QuickTime.pm:2619 — Product (string).
+        0x05 => ("Product", string_value(enc, value)?),
+        // Per QuickTime.pm:2620-2628 — TrackProperty (flags(N) + attr(n) + priority(n)).
+        0x0a => ("TrackProperty", track_property(value)?),
+        // Per QuickTime.pm:2629-2644 — TimeZone (Get16s minutes from UTC).
+        0x0b => {
+            if value.len() < 2 {
+                return None;
+            }
+            let raw = i16::from_be_bytes([value[0], value[1]]);
+            ("TimeZone", TypedValue::Integer(raw as i64))
+        }
+        // Per QuickTime.pm:2645-2657 — ModifyDate (YYYY/mm/dd HH:MM:SS).
+        0x0c => ("ModifyDate", string_value(enc, value)?),
+        _ => return None,
+    };
+    Some(MetadataEntry {
+        namespace: "sony_video".into(),
+        tag_id: format!("USMT/MTDT/0x{tag:04x}"),
+        tag_name: tag_name.into(),
+        value: typed,
+        provenance: Provenance {
+            container: container.into(),
+            namespace: "sony_video".into(),
+            path: Some("moov/uuid/USMT/MTDT".into()),
+            offset_start: Some(offset_start),
+            offset_end: None,
+            notes: Vec::new(),
+        },
+        notes: Vec::new(),
+    })
+}
+
+fn string_value(enc: u16, value: &[u8]) -> Option<TypedValue> {
+    let s = match enc {
+        0 => {
+            // 8-bit (Latin-1/ASCII subset). Strip trailing NUL.
+            let trimmed: Vec<u8> = value
+                .iter()
+                .copied()
+                .take_while(|b| *b != 0)
+                .filter(|b| (0x20..=0x7e).contains(b))
+                .collect();
+            String::from_utf8(trimmed).ok()?
+        }
+        1 => {
+            // UTF-16 BE.
+            if value.len() % 2 != 0 {
+                return None;
+            }
+            let words: Vec<u16> = value
+                .chunks_exact(2)
+                .map(|c| u16::from_be_bytes([c[0], c[1]]))
+                .take_while(|w| *w != 0)
+                .collect();
+            String::from_utf16(&words).ok()?
+        }
+        _ => return None,
+    };
+    if s.is_empty() {
+        return None;
+    }
+    Some(TypedValue::String(s))
+}
+
+/// Pack TrackProperty's three components into a stable string. ExifTool
+/// renders this as a `RawConv` of `unpack("Nnn", $val)` then a 3-element
+/// PrintConv list — we surface a compact `flags=N attr=N priority=N` string
+/// to keep the bounded shape simple while preserving the raw integers.
+fn track_property(value: &[u8]) -> Option<TypedValue> {
+    if value.len() < 8 {
+        return None;
+    }
+    let flags = u32::from_be_bytes([value[0], value[1], value[2], value[3]]);
+    let attr = u16::from_be_bytes([value[4], value[5]]);
+    let priority = u16::from_be_bytes([value[6], value[7]]);
+    Some(TypedValue::String(format!(
+        "flags={flags} attr={attr} priority={priority}"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Real bytes from `fixtures/local/C0242.MP4` USMT UUID at offset 25167294
+    /// (post-usertype slice — 28 bytes containing one MTDT box).
+    fn c0242_usmt_inner_first() -> Vec<u8> {
+        // 0000001c 4d544454 0001 0012 0000000a 55c4 0000 0000000100000000
+        hex_to_bytes("0000001c4d544454000100120000000a55c400000000000100000000")
+    }
+
+    fn hex_to_bytes(hex: &str) -> Vec<u8> {
+        hex.as_bytes()
+            .chunks(2)
+            .map(|c| u8::from_str_radix(std::str::from_utf8(c).unwrap(), 16).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn decodes_real_c0242_track_property() {
+        let bytes = c0242_usmt_inner_first();
+        let entries = decode_usmt(&bytes, 0, "mp4");
+        let track = entries
+            .iter()
+            .find(|e| e.tag_name == "TrackProperty")
+            .unwrap_or_else(|| panic!("no TrackProperty in {entries:?}"));
+        match &track.value {
+            TypedValue::String(s) => {
+                assert!(s.starts_with("flags="), "got {s}");
+                assert!(s.contains("attr="));
+                assert!(s.contains("priority="));
+            }
+            other => panic!("expected String, got {other:?}"),
+        }
+        assert_eq!(track.namespace, "sony_video");
+        assert_eq!(track.provenance.container, "mp4");
+    }
+
+    #[test]
+    fn ignores_unknown_tags_without_panic() {
+        // MTDT body: count=1, one record with unknown tag 0xdeadbeef, 8-byte value.
+        // 0001 0012 deadbeef 0000 0000 0000000000000000
+        let mtdt_body = hex_to_bytes("00010012deadbeef0000000000000000000000000000");
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&((mtdt_body.len() + 8) as u32).to_be_bytes());
+        bytes.extend_from_slice(b"MTDT");
+        bytes.extend_from_slice(&mtdt_body);
+        let entries = decode_usmt(&bytes, 0, "mp4");
+        assert!(entries.is_empty(), "got {entries:?}");
+    }
+
+    #[test]
+    fn decodes_synthetic_title_and_software() {
+        // Build an MTDT with two records: Title (0x01, ASCII "ABC") and
+        // Software (0x04, ASCII "X1"), both encoding=0.
+        // Record layout: size(2) tag(4) lang(2) enc(2) value(size-10).
+        let title = b"ABC\0";
+        let title_size: u16 = 10 + title.len() as u16;
+        let software = b"X1\0\0";
+        let sw_size: u16 = 10 + software.len() as u16;
+        let mut mtdt = Vec::new();
+        mtdt.extend_from_slice(&2u16.to_be_bytes()); // count
+        mtdt.extend_from_slice(&title_size.to_be_bytes());
+        mtdt.extend_from_slice(&0x0000_0001u32.to_be_bytes());
+        mtdt.extend_from_slice(&0u16.to_be_bytes()); // lang
+        mtdt.extend_from_slice(&0u16.to_be_bytes()); // enc
+        mtdt.extend_from_slice(title);
+        mtdt.extend_from_slice(&sw_size.to_be_bytes());
+        mtdt.extend_from_slice(&0x0000_0004u32.to_be_bytes());
+        mtdt.extend_from_slice(&0u16.to_be_bytes());
+        mtdt.extend_from_slice(&0u16.to_be_bytes());
+        mtdt.extend_from_slice(software);
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&((mtdt.len() + 8) as u32).to_be_bytes());
+        bytes.extend_from_slice(b"MTDT");
+        bytes.extend_from_slice(&mtdt);
+
+        let entries = decode_usmt(&bytes, 0, "mp4");
+        let title = entries
+            .iter()
+            .find(|e| e.tag_name == "Title")
+            .expect("Title");
+        assert!(matches!(&title.value, TypedValue::String(s) if s == "ABC"));
+        let sw = entries
+            .iter()
+            .find(|e| e.tag_name == "Software")
+            .expect("Software");
+        assert!(matches!(&sw.value, TypedValue::String(s) if s == "X1"));
+    }
+
+    #[test]
+    fn truncated_mtdt_returns_what_was_decoded() {
+        // count=2 but body only fits one record.
+        let mut mtdt = Vec::new();
+        mtdt.extend_from_slice(&2u16.to_be_bytes());
+        mtdt.extend_from_slice(&12u16.to_be_bytes()); // size
+        mtdt.extend_from_slice(&0x0000_0001u32.to_be_bytes()); // Title
+        mtdt.extend_from_slice(&0u16.to_be_bytes());
+        mtdt.extend_from_slice(&0u16.to_be_bytes());
+        mtdt.extend_from_slice(b"OK");
+        // intentionally no second record
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&((mtdt.len() + 8) as u32).to_be_bytes());
+        bytes.extend_from_slice(b"MTDT");
+        bytes.extend_from_slice(&mtdt);
+        let entries = decode_usmt(&bytes, 0, "mp4");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].tag_name, "Title");
+    }
+}

--- a/specs/drafts/118-sony-video-metadata.md
+++ b/specs/drafts/118-sony-video-metadata.md
@@ -1,0 +1,93 @@
+<!-- loswf:plan -->
+# Plan #118: Sony video metadata — native decoder for PROF/USMT UUID atoms in MP4/MOV
+
+## Problem
+Sony pro/prosumer video cameras (FX-series, A7-series video, A1) embed proprietary metadata in ISOBMFF `uuid` boxes under the **Sony User Data Atom UUID family** — a 16-byte usertype where bytes 0..4 are the atom name in ASCII and bytes 4..16 are the constant tail `21D24FCEBB88695CFAC9C740`. `xifty-container-isobmff` already structurally walks `uuid` boxes (see `crates/xifty-container-isobmff/src/lib.rs:1816-1903` `parse_uuid`), but only the Canon CMT UUID is dispatched; every other usertype emits an `isobmff_structure_recognized_uninterpreted` info-issue (line 1846-1853) and is dropped. There is no `xifty-meta-sony-video` crate; `xifty-meta-sony` is JPEG MakerNote and does not apply. Snapshots `extract_real_camera_mp4_normalized` / `extract_real_camera_mp4_interpreted` (`crates/xifty-cli/tests/cli_contract.rs:1185,1194`) currently have `.snap.new` regressions on `fixtures/local/C0242.MP4` because of the new info-issue noise introduced by PR #117.
+
+## Approach
+Mirror PR #117's Canon CMT pattern exactly:
+1. Add a new `xifty-meta-sony-video` crate (peer of `xifty-meta-canon`/`-fuji`/`-olympus`) with `decode_prof()` + `decode_usmt()` functions and a `SUPPORTED_USERTYPES` registry. Decoders are pure: take `&[u8]`, `base_offset: u64`, `container_name: &str` and return `Vec<MetadataEntry>` with `namespace = "sony_video"`. Field maps reverse-engineered from ExifTool's `Sony.pm` (the `SonyUserData`, `PROF`, `USMT` Tags tables) and `QuickTime.pm` (`UserData` hash) — read for understanding, port to Rust, ship Rust only. Cite ExifTool source line/section in doc comments per derived tag.
+2. In `xifty-container-isobmff`, add a `SONY_USERDATA_UUID_TAIL: [u8; 12] = [0x21,0xD2,0x4F,0xCE,0xBB,0x88,0x69,0x5C,0xFA,0xC9,0xC7,0x40]` constant and extend `parse_uuid` (line 1816-1903) so that when `usertype[4..16] == SONY_USERDATA_UUID_TAIL`, an `IsobmffPayload { kind: "sony-video-atom", tag: Some(<atom-name from usertype[0..4] ASCII>), … }` is emitted with the inner data slice (offsets exclude the 16 usertype bytes; data_offset = parsed.data_offset + 16; data_length = parsed.end - inner_start). Add `pub fn sony_video_atoms()` accessor mirroring `canon_cmt_payloads()` (line 150). Refine the residual unrecognized branch to populate a richer issue body (see step 4).
+3. In `xifty-cli/src/lib.rs`, plumb dispatch in the ISOBMFF extract paths used by mp4/mov (the `Format::Mp4`/`Format::Mov` branches around the call sites at lines 283-291 and the existing `cr3_extract` at line 772 is the structural template). Iterate `isobmff.sony_video_atoms()`; for each payload match `tag.as_deref()` against `"PROF" | "USMT"` and call the corresponding decoder, with `container_name = "mp4"` or `"mov"` (from the format detected upstream) so provenance reads `container: "mp4"`, `namespace: "sony_video"`.
+4. Refine `isobmff_structure_recognized_uninterpreted` (line 1846-1853) so the issue's `message` includes the 16-byte usertype as lowercase hex (e.g. `"recognized uuid box but the usertype 21d24fce…c740 is not handled"`), making future unknown UUIDs actionable.
+5. Update `CAPABILITIES.json`: add `"sony_video"` to the top-level `namespaces` map with `status: bounded` and the explicit `supported_tags` list; add `sony_video: bounded` under `containers.mp4.namespaces` and `containers.mov.namespaces`.
+6. Regenerate the two failing insta snapshots (`extract_real_camera_mp4_normalized.snap` and `extract_real_camera_mp4_interpreted.snap`) so they show real decoded `sony_video` entries instead of the noise issues; verify by running `cargo insta review` and inspecting diffs.
+
+### Bounded ship list (Phase 1, this PR)
+
+Cinematographer-relevant subset, explicitly bounded:
+
+**PROF atom** (Picture Profile):
+- `PictureProfile` (string, e.g. "PP10")
+- `GammaCategory` (enum: Movie / Still / Cine1 / Cine2 / ITU709 / ITU709(800) / S-Log2 / S-Log3 / HLG / HLG1/2/3)
+- `ColorSpace` (enum: S-Gamut / S-Gamut3 / S-Gamut3.Cine / BT.709 / BT.2020)
+- `BlackLevel` (i16)
+- `KneePoint` (u8 percent)
+- `KneeSlope` (i8)
+- `DetailLevel` (i8)
+- `ColorMode` (enum)
+
+**USMT atom** (User SMPTE-style metadata):
+- `ShootingMode` (enum: Program / Aperture / Shutter / Manual / Movie / etc.)
+- `AFMode` (enum: Manual / AF-S / AF-C / AF-A / DMF)
+- `WhiteBalanceMode` (enum: Auto / Daylight / Shade / Cloudy / Tungsten / Fluorescent / Flash / ColorTemp / Custom)
+- `ColorTemperature` (u16 Kelvin, when WB mode = ColorTemp)
+
+PRPF/MTDT/AOLY are deferred to follow-up issues (recognise the usertype but emit `kind = "sony-video-atom"` with the tag — decoder routes them through; absent decoder branch is a no-op, no info-issue, since they're declared as known). The issue list in `parse_uuid` distinguishes "unknown usertype family" (info-issue with hex) from "known Sony family but no decoder yet" (no issue, since dispatch is silent).
+
+## Files to touch
+- `Cargo.toml` (workspace) — register new `crates/xifty-meta-sony-video` member.
+- `crates/xifty-container-isobmff/src/lib.rs` — add `SONY_USERDATA_UUID_TAIL`, extend `parse_uuid` (line 1816-1903) with Sony branch, add `sony_video_atoms()` accessor near line 150, enrich the uninterpreted issue body (line 1849).
+- `crates/xifty-container-isobmff/Cargo.toml` — no change expected.
+- `crates/xifty-cli/Cargo.toml` — add `xifty-meta-sony-video = { path = "../xifty-meta-sony-video" }`.
+- `crates/xifty-cli/src/lib.rs` — `use xifty_meta_sony_video::{decode_prof, decode_usmt};`; wire dispatch in the mp4/mov extract path (the same area where quicktime/rtmd entries are accumulated, search for `.quicktime_payloads()` / non_real_time_meta).
+- `crates/xifty-cli/tests/cli_contract.rs` — no functional change; snapshot tests at lines 1185/1194 will regenerate.
+- `crates/xifty-cli/tests/snapshots/cli_contract__extract_real_camera_mp4_normalized.snap` — regenerate via `cargo insta review`.
+- `crates/xifty-cli/tests/snapshots/cli_contract__extract_real_camera_mp4_interpreted.snap` — regenerate via `cargo insta review`.
+- `CAPABILITIES.json` — add `sony_video` namespace; mark mp4/mov containers.
+
+## New files
+- `crates/xifty-meta-sony-video/Cargo.toml` — peer of `xifty-meta-canon/Cargo.toml`; deps: `xifty-core` only (decoders consume `&[u8]`, no TIFF/source needed since UUID payloads are flat structured big-endian blobs).
+- `crates/xifty-meta-sony-video/src/lib.rs` — `decode_prof`, `decode_usmt`, `SUPPORTED_USERTYPES: &[&str]`, internal field-map tables, unit tests.
+- `crates/xifty-meta-sony-video/src/prof.rs` — PROF decoder + `GammaCategory`/`ColorSpace`/`ColorMode` enum lookup tables (cite ExifTool `Sony.pm` `%Image::ExifTool::Sony::PictureProfile` / `ProcessSonyPIC` references in comments).
+- `crates/xifty-meta-sony-video/src/usmt.rs` — USMT decoder + `ShootingMode`/`AFMode`/`WhiteBalanceMode` lookup tables (cite ExifTool `Sony.pm` `SonyUserData` and `Sony::Tag9050b` mappings).
+- `fixtures/minimal/sony_video.mp4` — synthetic minimal ISOBMFF: `ftyp(isom...) + moov(uuid<PROF>{minimal PROF blob} + uuid<USMT>{minimal USMT blob})`. Built with the same `boxed()` helper pattern in the existing isobmff tests (see line 2122-2130 for the Canon synthesis precedent). Committed (synthetic, no copyrighted bytes).
+
+## Step-by-step
+1. **Read ExifTool reference** — fetch the relevant tables in `lib/Image/ExifTool/Sony.pm` (`SonyUserData`, `PictureProfile`, `Tag9050b` for AF/WB enums) and `lib/Image/ExifTool/QuickTime.pm` (`UserData` hash) from github.com/exiftool/exiftool. Document the exact line ranges in each decoder's module-level comment so reviewers can audit. **Verifiable**: doc comments cite `Sony.pm` lines.
+2. **Create `xifty-meta-sony-video` skeleton** — Cargo.toml mirroring `xifty-meta-canon`'s; empty `lib.rs` exposing `decode_prof`, `decode_usmt`, `SUPPORTED_USERTYPES`; register in workspace `Cargo.toml`. **Verifiable**: `cargo check -p xifty-meta-sony-video`.
+3. **Implement PROF decoder** — parse the PROF blob's TLV/fixed-offset layout per ExifTool reference; populate `MetadataEntry` for each tag in the bounded ship list with `namespace="sony_video"`, `tag_id=<atom>:<offset_or_id>`, typed values, and provenance (container name from arg, `path = "moov/uuid/PROF"`). **Verifiable**: unit test in `prof.rs` decodes a hand-built PROF buffer and asserts each field type.
+4. **Implement USMT decoder** — same shape; USMT is a SMPTE-keyed structure (4-byte FourCC keys + length + value) per ExifTool. Walk the keys, dispatch the bounded subset, ignore unknowns. **Verifiable**: unit test in `usmt.rs`.
+5. **Add `SONY_USERDATA_UUID_TAIL` const + extend `parse_uuid`** — when `usertype[4..16] == SONY_USERDATA_UUID_TAIL`, decode `usertype[0..4]` as ASCII (validate printable), build payload with `kind="sony-video-atom"`, `tag=Some(name)`. The existing Canon branch stays first; the Sony branch sits before the residual `isobmff_structure_recognized_uninterpreted` else-arm. **Verifiable**: existing unknown-UUID test still passes with all-zero usertype; new test asserts a synthetic Sony-PROF UUID surfaces a payload.
+6. **Add `sony_video_atoms()` accessor** on `IsobmffParse` near line 150, filtering `payload.kind == "sony-video-atom"`. **Verifiable**: doc-tested or used by the new isobmff unit test.
+7. **Enrich the uninterpreted issue body** — lowercase-hex-format the 16-byte usertype into the message (or `context`). Keep code stable (`isobmff_structure_recognized_uninterpreted`). **Verifiable**: existing unknown-UUID test updated to check the hex appears in `message`.
+8. **Wire CLI dispatch** in `xifty-cli/src/lib.rs` — for the mp4/mov extract code path, after quicktime entries are collected, iterate `isobmff.sony_video_atoms()`; for each, slice `payload_bytes` (using existing `payload_slice` helper, see line 791), match on `payload.tag.as_deref()`, call decoder, extend `entries`. Pass `container_name = "mp4"` (or `"mov"` for the mov path). **Verifiable**: snapshot tests show `sony_video` entries.
+9. **Synthesize `fixtures/minimal/sony_video.mp4`** — emit ftyp + moov with two synthetic UUID boxes (PROF + USMT). Use the same `boxed()` helper from isobmff tests as a model. Add a CLI snapshot test `extract_snapshot_synthetic_sony_video` that exercises end-to-end dispatch without depending on `fixtures/local/`. **Verifiable**: new snapshot file committed.
+10. **Regenerate failing snapshots** — run `cargo test -p xifty-cli`, then `cargo insta review` on the two `*real_camera_mp4*` snapshots. Diff should drop the noise info-issues and add `sony_video` entries. **Verifiable**: snapshot diff inspected line-by-line in PR description; no `.snap.new` left over.
+11. **Update `CAPABILITIES.json`** — add the `sony_video` namespace with bounded status and the explicit `supported_tags` list; add `sony_video: bounded` to `containers.mp4.namespaces` and `containers.mov.namespaces`. **Verifiable**: `Docs And Contract` hygiene check passes.
+12. **Run full validation suite** — see Validation section.
+
+## Tests
+- `crates/xifty-meta-sony-video/src/prof.rs` `#[cfg(test)] mod tests` — hand-built PROF byte buffer covering each bounded field; assert one `MetadataEntry` per field, correct typed value, correct enum decoding, correct provenance.
+- `crates/xifty-meta-sony-video/src/usmt.rs` `#[cfg(test)] mod tests` — hand-built USMT key/length/value buffer; assert ShootingMode/AFMode/WB decode; assert unknown keys are ignored without panic.
+- `crates/xifty-container-isobmff/src/lib.rs` `tests` — extend with `recognizes_sony_userdata_uuid_family()` (synthetic Sony PROF UUID box → one `sony-video-atom` payload with tag `PROF`); update `ignores_unknown_uuid_box()` to assert the issue `message` now contains the usertype hex.
+- `crates/xifty-cli/tests/cli_contract.rs` — new `extract_snapshot_synthetic_sony_video` (uses committed `fixtures/minimal/sony_video.mp4`; not gated on `local/`); existing `extract_snapshot_real_camera_mp4_*` regenerated to show real decoded fields.
+
+## Validation
+Per `.loswf/config.yaml`:
+1. `cargo fmt --all -- --check`
+2. `cargo test --workspace --all-features`
+3. `cargo test -p xifty-ffi --all-features`
+
+CI gating: `Rust Core`, `Runtime Artifact (macos-arm64)`, `Runtime Artifact (linux-x64)`, `Lambda Node Example`, `Docs And Contract` (this last one validates `CAPABILITIES.json` shape).
+
+Snapshot drift policy: use `cargo insta review` deliberately on the two regenerated `extract_real_camera_mp4_*` snapshots; reviewer must inspect diffs (per SRS §3 invariant 6 and `.loswf/config.yaml` guardrail).
+
+## Risks
+- **PROF/USMT field-map accuracy** — without official Sony docs, ExifTool is the de-facto reference. Mitigation: cite source line per tag, keep Phase 1 to the well-attested cinematographer subset, and verify against `C0242.MP4` extracted values cross-referenced with `exiftool C0242.MP4` output (read-only, comparison only — no shipping dep).
+- **USMT structure variance across firmware** — different FX bodies emit different USMT layouts. Mitigation: tolerant walker (skip-on-unknown-key, skip-on-bad-length); never panic; emit a per-atom info-issue if the structure is structurally invalid.
+- **Atom-name validation in `parse_uuid`** — usertype[0..4] could be non-printable on a malformed UUID that happens to share the tail. Mitigation: require ASCII alphanumeric (3-4 chars), else fall through to the uninterpreted branch with hex.
+- **Synthetic fixture realism** — minimal byte buffers may not exercise the real layout. Mitigation: keep `fixtures/local/C0242.MP4` snapshot test as the integration truth; synthetic fixture exists for unit-level dispatch only.
+- **Provenance container name** — current ISOBMFF dispatch doesn't always thread the detected format down. Mitigation: pass `"mp4"` vs `"mov"` from the `Format` enum match arm explicitly (the cr3_extract precedent at line 772 hard-codes `"cr3"`; we follow the same shape).
+- **Issue body change is a soft contract change** — any downstream consumer keying on the exact message string of `isobmff_structure_recognized_uninterpreted` would break. Code stays stable; only message text changes. Acceptable per the issue's acceptance criteria.
+


### PR DESCRIPTION
Closes #118

## Summary

- New crate `xifty-meta-sony-video` ships a 100% native Rust decoder for Sony's PROF (Picture Profile) and USMT (User SMPTE-style metadata) UUID atoms found in MP4/MOV files from FX-series, A7-series video, and A1 cameras.
- Field maps reverse-engineered from ExifTool `lib/Image/ExifTool/QuickTime.pm` (`%QuickTime::FileProf`, `%AudioProf`, `%VideoProf`, `%MetaData`, `ProcessMetaData`). Reference material only — read to understand, port to Rust, ship Rust. Per-tag source citations live in code comments.
- `xifty-container-isobmff::parse_uuid` now recognises the Sony "User Data Atom UUID family" (16-byte usertype = 4-byte ASCII atom name + 12-byte tail `21d24fcebb88695cfac9c740`) and surfaces each atom as `kind = "sony-video-atom"` via a new `sony_video_atoms()` accessor.
- The `isobmff_structure_recognized_uninterpreted` info-issue body now carries the lowercase-hex usertype so future unknowns are actionable from the issue stream alone.
- `xifty-cli::isobmff_entries` dispatches PROF/USMT to the new decoder for both MP4 and MOV (single insertion point per plan-reviewer callout #2).
- `CAPABILITIES.json` declares the `sony_video` namespace (bounded, 22 tags) and adds `sony_video: bounded` to mp4 + mov containers.

### Decoded fields surfaced from `fixtures/local/C0242.MP4`

The previously failing `extract_real_camera_mp4_interpreted.snap` regression caused by PR #117 is replaced by 19 real Sony fields:

```
FileFunctionFlags=536870912     (Edited bit set)
VideoCodec=avc1                 VideoTrackID=1
VideoSize=3840x2160             PixelAspectRatio=1:1
VideoAvgFrameRate=23.976 fps    VideoMaxFrameRate=23.976 fps
VideoAvgBitrate=100 Mbps        VideoMaxBitrate=100 Mbps
AudioCodec=twos                 AudioTrackID=2
AudioSampleRate=48000 Hz        AudioChannels=2
AudioAvgBitrate=1.536 Mbps      AudioMaxBitrate=1.536 Mbps
TrackProperty x3                TimeZone=-480 (UTC-8)
```

## Plan-reviewer callouts resolved

1. ✅ **xifty-source as required dep** — added; `Cursor`/`Endian` used throughout.
2. ✅ **Dispatch in `isobmff_entries`** — single insertion point, not duplicated per format arm.
3. ✅ **USMT wire format verified from ExifTool first** — `ProcessMetaData` (`QuickTime.pm:9573-9619`) gives the exact `count(2) + size(2) + tag(4) + lang(2) + enc(2) + value` layout. The plan's TLV speculation (and its proposed USMT ship list `ShootingMode/AFMode/WhiteBalanceMode/ColorTemperature`) did not match the actual MTDT layout — those tags don't exist in `%QuickTime::MetaData`. Bounded ship list adjusted to the well-attested `Title/ProductionDate/Software/Product/TrackProperty/TimeZone/ModifyDate` per `QuickTime.pm:2599-2658`.

## Deviations from plan

- **No synthetic minimal `fixtures/minimal/sony_video.mp4`** — per plan-reviewer callout #3 fallback ("if you cannot perfectly synthesize the USMT layout from public sources, fall back to gating the USMT integration test on `fixtures/local/C0242.MP4` only"), unit tests use byte-array literals derived from the actual `C0242.MP4` dump and the existing real-camera snapshot tests cover end-to-end dispatch. Revisitable in a follow-up.
- **USMT ship list refined** to match the real MTDT contents per ExifTool — see callout #3 above.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --all-features` — all green
- [x] `cargo test -p xifty-ffi --all-features` — all green
- [x] `python3 tools/generate_capabilities.py --check` — passes (only pre-existing fixture-coverage warnings)
- [x] `xifty-meta-sony-video` unit tests: 7 passed (PROF + USMT + provenance + truncation + unknown-tag tolerance)
- [x] `xifty-container-isobmff` unit tests: 20 passed (incl. new `recognizes_sony_userdata_uuid_family` and updated `ignores_unknown_uuid_box` for hex-in-message)
- [x] Snapshot regeneration on `extract_real_camera_mp4_interpreted` — diffs inspected; only intended additions (drops noise issues, adds real Sony fields)
- [x] `extract_real_camera_mp4_normalized` snapshot was unaffected (issues stream is not part of normalized view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)