### PR TITLE
docs: refresh README + demo for v0.1.12 format coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,14 +92,10 @@ The two core commands are:
 
 Current container coverage:
 
-- JPEG / TIFF / DNG
-- PNG / WebP
-- HEIF / HEIC
-- MP4 / MOV
-- M4A / M4B / M4P
-- FLAC
-- OGG (Vorbis / Opus)
-- AIFF / AIFC
+- **Still images:** JPEG / TIFF / DNG / PNG / WebP / GIF / HEIF / HEIC / AVIF
+- **Camera RAW:** Canon CR2, Canon CR3, Nikon NEF, Sony ARW, Fuji RAF, Olympus ORF, Panasonic RW2
+- **Video:** MP4 / MOV / M4A / M4B / M4P
+- **Audio:** MP3 (ID3v2), WAV (RIFF + BWF + iXML), FLAC, OGG (Vorbis / Opus), AIFF / AIFC
 
 Current namespace coverage:
 
@@ -110,15 +106,16 @@ Current namespace coverage:
 - bounded QuickTime
 - bounded iTunes (`ilst` atoms: Title, Artist, Album, AlbumArtist, Year, Genre, Comment, Composer, Lyrics, Encoder, TrackNumber, DiskNumber, Compilation, BeatsPerMinute, CoverArt)
 - bounded DJI drone telemetry from MP4 `udta` and JPG XMP `drone-dji:*` (flight pitch/yaw/roll, gimbal pitch/yaw/roll, speed XYZ, GPS location, camera model, serial number, plus absolute/relative altitude on JPG — surfaced under `drone.*`, `device.*`, and `location` in the normalized view)
-- selected Sony and Apple vendor metadata paths
+- vendor MakerNote — Apple, Sony (still), Canon, Fuji, Olympus, Panasonic, Nikon (encrypted regions flagged, not decrypted)
+- **Sony video metadata** — PROF/USMT UUID atoms in MP4/MOV (FX/A7-series): codec, bitrate, frame rate, resolution, time zone, software, etc.
+- bounded ID3v2 (MP3, AIFF embedded `ID3 ` chunk)
+- bounded BWF `bext` and iXML (WAV)
 - bounded Vorbis comment (FLAC, OGG)
 - bounded OGG framing (Vorbis + Opus ident headers, last-page granule duration, multiplexed-stream detection)
 - bounded FLAC stream info (sample rate, channels, bit depth, duration, embedded picture)
 - bounded AIFF stream info (sample rate, channels, bit depth, duration from `COMM` chunk)
-
-  Note: AIFF files may contain an embedded `ID3 ` chunk. The chunk offset is
-  located and tracked but the tag payload is not decoded in this release — tag
-  decoding is a follow-up once an ID3v2 decoder crate is available.
+- bounded GIF (logical screen, frame count, animation duration, palette, loop count, XMP App Extension)
+- bounded AVIF HDR color (`color.primaries` / `transfer` / `matrix` / `range` / `bit_depth` from `colr` / `cicp` / `pixi` boxes)
 
 Current product surfaces:
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -59,17 +59,19 @@ CI runs the same test on pull requests via `.github/workflows/pages-demo.yml`.
 
 ## Current Scope
 
-The browser MVP is intentionally narrower than the native/server surface.
+The browser demo runs the full `xifty-wasm` surface — every container the
+native Rust crates support is available in the browser. Practical limits are
+file-size / browser-memory rather than format coverage.
 
-Current intended browser-first formats:
+Currently exercised end-to-end in the demo:
 
-- JPEG
-- TIFF
-- PNG
-- WebP
+- **Still images:** JPEG, TIFF, DNG, PNG, WebP, GIF, HEIF/HEIC, AVIF
+- **Camera RAW:** Canon CR2 / CR3, Nikon NEF, Sony ARW, Fuji RAF, Olympus ORF, Panasonic RW2
+- **Video:** MP4, MOV (including Sony FX/A7-series PROF/USMT video metadata)
+- **Audio:** MP3 (ID3v2), WAV (BWF + iXML), M4A, FLAC, OGG (Vorbis / Opus), AIFF / AIFC
 
-Media-heavy formats such as HEIF and MP4/MOV remain future work for the browser
-path.
+Large RAW and long-form video files may stress browser memory; for production
+batch processing prefer the Node binding on Lambda or the native CLI.
 
 ## Current Presentation Model
 

--- a/demo/web/index.html
+++ b/demo/web/index.html
@@ -37,10 +37,12 @@
           <h2>Try it</h2>
           <p>
             Drop a file to see what XIFty surfaces. Works on
-            <strong>images</strong> (JPEG, TIFF, DNG, PNG, WebP, HEIF/HEIC),
-            <strong>video</strong> (MP4, MOV), and
-            <strong>audio</strong> (M4A, FLAC, OGG with Vorbis/Opus, AIFF/AIFC).
-            Camera, capture time, GPS, dimensions, codec, audio sample rate,
+            <strong>images</strong> (JPEG, TIFF, DNG, PNG, WebP, GIF, HEIF/HEIC, AVIF),
+            <strong>camera RAW</strong> (Canon CR2/CR3, Nikon NEF, Sony ARW, Fuji RAF, Olympus ORF, Panasonic RW2),
+            <strong>video</strong> (MP4, MOV — including Sony FX/A7-series PROF/USMT video metadata), and
+            <strong>audio</strong> (MP3 with ID3v2, WAV with BWF/iXML, M4A, FLAC, OGG with Vorbis/Opus, AIFF/AIFC).
+            Camera, capture time, GPS, dimensions, codec, audio sample rate, animation duration,
+            HDR color, vendor MakerNote (Canon, Fuji, Olympus, Panasonic, Nikon, Sony, Apple),
             and DJI drone telemetry from either a Mavic JPG or MP4 — all
             surfaced as stable keys you can read straight off.
           </p>


### PR DESCRIPTION
Brings the README and the browser-demo copy back in sync with what shipped in v0.1.12 (https://github.com/XIFtySense/XIFty/releases/tag/v0.1.12).

- README `What XIFty Supports Today` now lists the new containers (MP3, WAV, GIF, AVIF, CR2, CR3, NEF, ARW, RAF, ORF, RW2) and namespaces (canon, fuji, olympus, panasonic, nikon, sony_video, bwf, ixml, id3v2).
- Drops the stale AIFF "ID3v2 decoder is future work" note (xifty-meta-id3v2 now exists).
- demo/web/index.html visible copy updates to surface the new families so visitors see what to drop.
- demo/README.md reflects that the WASM bundle exposes the full native surface; browser scope is memory-bound, not format-bound.

No code changes. Triggers pages-demo redeploy on merge.