### PR TITLE
chore: Phase 1 sidecar polish — pub const + doc + entity decode + test coverage (#128, #129)

### DIFF
--- a/crates/xifty-cli/tests/cli_contract.rs
+++ b/crates/xifty-cli/tests/cli_contract.rs
@@ -3187,12 +3187,17 @@ fn sony_nrt_sidecar_synthetic_minimal_fixture_lifts_fields() {
         .iter()
         .map(|f| (f["field"].as_str().unwrap().to_string(), f.clone()))
         .collect();
+    // All 12 normalized fields lifted by `derive_sony_nrt_fields` for Phase 1.
+    // Keep this list in lockstep with the unit-test coverage in
+    // `xifty-normalize::tests::lifts_sony_nrt_sidecar_fields_from_namespace`.
     for required in [
         "umid",
         "recording.mode",
+        "recording.cache_rec",
         "recording.capture_fps",
         "recording.format_fps",
         "timecode.fps",
+        "timecode.half_step",
         "timecode.ltc.start",
         "timecode.ltc.end",
         "color.gamma_equation",

--- a/crates/xifty-sidecar-sony-nrt/src/lib.rs
+++ b/crates/xifty-sidecar-sony-nrt/src/lib.rs
@@ -19,7 +19,8 @@ use quick_xml::events::{BytesStart, Event};
 use quick_xml::reader::Reader;
 use xifty_core::{Issue, MetadataEntry, Provenance, Severity, TypedValue};
 use xifty_sidecar::{
-    MergeContext, MergePolicy, SIDECAR_UNKNOWN_SCHEMA_VERSION, Sidecar, SidecarPayload, SidecarRef,
+    MergeContext, MergePolicy, SIDECAR_PARSE_ERROR, SIDECAR_UNKNOWN_SCHEMA_VERSION, Sidecar,
+    SidecarPayload, SidecarRef,
 };
 
 const NAMESPACE: &str = "sony_nrt";
@@ -158,8 +159,6 @@ fn parse_nrt(sidecar: &SidecarRef, bytes: &[u8]) -> SidecarPayload {
     let mut entries: Vec<MetadataEntry> = Vec::new();
     let mut issues: Vec<Issue> = Vec::new();
     let mut buf = Vec::new();
-    #[allow(unused_assignments)]
-    let mut schema = SchemaVersion::Unknown;
     let mut in_acquisition_camera_unit = false;
     // Track first vs last LtcChange (per Sony NRT XSD §LtcChangeTable
     // schema, the table sorts by `frameCount`; we capture the first/last
@@ -176,7 +175,7 @@ fn parse_nrt(sidecar: &SidecarRef, bytes: &[u8]) -> SidecarPayload {
                 // Root element — capture the schema version from xmlns.
                 // per Sony NRT XSD ver.2.20 root <NonRealTimeMeta>.
                 if local == "NonRealTimeMeta" {
-                    schema = detect_schema(e);
+                    let schema = detect_schema(e);
                     if schema == SchemaVersion::Unknown {
                         let xmlns = attr_value(e, b"xmlns").unwrap_or_default();
                         issues.push(Issue {
@@ -470,7 +469,7 @@ fn parse_nrt(sidecar: &SidecarRef, bytes: &[u8]) -> SidecarPayload {
             Err(error) => {
                 issues.push(Issue {
                     severity: Severity::Warning,
-                    code: "sidecar_parse_error".into(),
+                    code: SIDECAR_PARSE_ERROR.into(),
                     message: format!("Sony NRT XML parse error: {error}"),
                     offset: Some(reader.buffer_position()),
                     context: Some(NAMESPACE.into()),
@@ -544,6 +543,22 @@ fn bytes_to_local_name(name: &[u8]) -> String {
     }
 }
 
+/// Read a Sony NRT attribute value as a UTF-8 string.
+///
+/// We deliberately do NOT call `attr.decode_and_unescape_value(...)` here.
+/// Every Sony NRT attribute payload defined in XSD ver.2.10 / ver.2.20 is
+/// constrained to ASCII-clean tokens (UMID hex, FPS strings, codec names,
+/// SMPTE timecodes, serial numbers, enum-style values like `s-log3` /
+/// `rec2020` / `normal`). None carry XML entity references in real-world
+/// camera output, and the `xmlns` attribute we read at the root is a fixed
+/// schema URN.
+///
+/// If a future Sony schema version (or a hand-edited sidecar) introduces
+/// entity-encoded values such as `manufacturer="Foo &amp; Bar"`, this reader
+/// would surface them with `&amp;` intact. Switching to
+/// `decode_and_unescape_value(reader.decoder())` would fix that, but requires
+/// threading the decoder through every call site. Defer until we see a real
+/// fixture that needs it.
 fn attr_value(e: &BytesStart<'_>, key: &[u8]) -> Option<String> {
     for attr in e.attributes().flatten() {
         // Match by local part — Sony NRT does not prefix its own attributes

--- a/crates/xifty-sidecar/src/lib.rs
+++ b/crates/xifty-sidecar/src/lib.rs
@@ -25,6 +25,10 @@ use xifty_core::{Issue, MetadataEntry, Severity};
 pub const SIDECAR_TARGET_MISSING: &str = "sidecar_target_missing";
 pub const SIDECAR_NO_INDEX_ENTRY: &str = "sidecar_no_index_entry";
 pub const SIDECAR_UNKNOWN_SCHEMA_VERSION: &str = "sidecar_unknown_schema_version";
+/// Emitted by a sidecar adapter when its underlying file fails to parse
+/// (e.g. malformed XML). Severity is left to the adapter — Sony NRT raises
+/// it as `Warning` because the embedded MP4 metadata still flows through.
+pub const SIDECAR_PARSE_ERROR: &str = "sidecar_parse_error";
 
 /// Code emitted by the WASM surface when a caller asks for sidecar discovery
 /// in a context with no filesystem access. Defined here so adapters and
@@ -33,10 +37,13 @@ pub const SIDECAR_DISCOVERY_UNAVAILABLE_IN_WASM: &str = "sidecar_discovery_unava
 
 /// How an adapter wants its parsed entries reconciled with embedded metadata.
 ///
-/// `Override` writes the sidecar-derived value first and downgrades any
-/// embedded entry that targets the same field to a conflict candidate.
+/// `Override`: sidecar entries silently replace embedded entries for the same
+/// field. The embedded value does NOT reach the conflict detector — only the
+/// sidecar value does. Use this for sidecars whose entire purpose is overriding
+/// embedded metadata (e.g. Adobe XMP sidecars carrying non-destructive
+/// Lightroom edits).
 ///
-/// `Complement` lets both entries flow through the normal pipeline; the
+/// `Complement`: lets both entries flow through the normal pipeline; the
 /// existing conflict-detector flags overlap if any.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MergePolicy {
@@ -179,10 +186,10 @@ impl SidecarRegistry {
             issues.extend(payload.issues);
             match hit.adapter.merge_policy() {
                 MergePolicy::Override => {
-                    // Replace embedded entries that target the exact same
-                    // (namespace, tag_name) pair with the sidecar version.
-                    // Conflict-detection downstream catches the cross-source
-                    // disagreement.
+                    // Silently replace embedded entries that target the same
+                    // tag_name from a different namespace. The embedded value
+                    // is dropped before downstream conflict detection runs,
+                    // so only the sidecar value survives.
                     for sidecar_entry in payload.entries {
                         entries.retain(|existing| {
                             !(existing.tag_name == sidecar_entry.tag_name

--- a/docs/SCHEMA_POLICY.md
+++ b/docs/SCHEMA_POLICY.md
@@ -120,6 +120,20 @@ for those entries is:
   `xifty_extract_json_with_options` entrypoint with `enable_sidecars: true`,
   and (in WASM, where it's a no-op) emits an `info`-severity issue
   (`sidecar_discovery_unavailable_in_wasm`).
+- Sidecar adapters surface problems through the standard `report.issues`
+  channel. The stable issue codes are:
+  - `sidecar_target_missing` — adapter referenced a sidecar but the file
+    could not be read.
+  - `sidecar_no_index_entry` — adapter looked up a primary asset in an
+    index sidecar (e.g. MEDIAPRO `mediapro.xml`) and did not find a
+    matching entry.
+  - `sidecar_unknown_schema_version` — the sidecar's declared schema /
+    namespace is not recognized by the adapter; partial parse may still
+    proceed.
+  - `sidecar_parse_error` — the underlying sidecar file failed to parse
+    (e.g. malformed XML); embedded metadata still flows through.
+  - `sidecar_discovery_unavailable_in_wasm` — caller asked for sidecar
+    discovery on a surface (WASM) with no filesystem access.
 - Sidecar additions are *additive only* — no `SCHEMA_VERSION` bump.
 
 ## Design Intent

--- a/specs/drafts/128-sidecar-polish.md
+++ b/specs/drafts/128-sidecar-polish.md
@@ -1,0 +1,55 @@
+## Context
+
+Reviewer findings from PR #127 (Phase 1 sidecar framework + Sony NRT adapter, #122) — non-blocking advisory items captured here for follow-up.
+
+## Item 1 — promote \`sidecar_parse_error\` to \`pub const\`
+
+**File:** \`crates/xifty-sidecar-sony-nrt/src/lib.rs:473\`
+
+The Sony NRT adapter emits \`\"sidecar_parse_error\"\` as a raw string literal when \`quick-xml\` parsing fails. All other sidecar issue codes (\`sidecar_target_missing\`, \`sidecar_no_index_entry\`, \`sidecar_unknown_schema_version\`, \`sidecar_discovery_unavailable_in_wasm\`) are stable \`pub const\`s in \`crates/xifty-sidecar/src/lib.rs\`.
+
+This creates a stability gap: the literal can drift silently across refactors and the value is not documented in \`CAPABILITIES.json\` or \`docs/SCHEMA_POLICY.md\`. Consumers filtering on issue codes will miss it.
+
+**Fix:**
+- Add \`pub const SIDECAR_PARSE_ERROR: &str = \"sidecar_parse_error\";\` to \`xifty-sidecar/src/lib.rs\` alongside the other four constants.
+- Update the sony-nrt callsite to use the constant.
+- Add the code to the documented sidecar issue codes list.
+
+## Item 2 — fix \`MergePolicy::Override\` doc comment
+
+**File:** \`crates/xifty-sidecar/src/lib.rs:182-184\`
+
+Current doc comment claims \"Conflict-detection downstream catches the cross-source disagreement\" — but the actual implementation removes the embedded entry via \`entries.retain(...)\` before pushing the sidecar entry. Only one entry survives; the conflict detector sees nothing to flag. The behavior is correct for a true override (silent replacement), but the comment will mislead Phase 4 (#125) implementers building the Adobe XMP sidecar adapter.
+
+**Fix:** rewrite the comment to:
+\`\`\`
+/// Sidecar entries silently replace embedded entries for the same field.
+/// The embedded value does NOT reach the conflict detector — only the sidecar value does.
+/// Use this for sidecars whose entire purpose is overriding embedded metadata
+/// (e.g. Adobe XMP sidecars carrying non-destructive Lightroom edits).
+\`\`\`
+
+## Item 3 — minor: \`attr_value\` does not decode XML entity references
+
+**File:** \`crates/xifty-sidecar-sony-nrt/src/lib.rs:390-403\`
+
+Currently reads \`attr.value\` raw. For all known Sony NRT attribute payloads (UMID hex, FPS strings, codec names, serial numbers) this is fine — none carry encoded entities. Future Sony schema versions or device names with \`&amp;\` would surface as raw entity strings.
+
+**Fix:** add an inline comment documenting the assumption + cite which Sony NRT attribute values are guaranteed-no-entities. Or call \`attr.decode_and_unescape_value(reader)\` if cheap; benchmark first.
+
+## Item 4 — minor style cleanup
+
+**File:** \`crates/xifty-sidecar-sony-nrt/src/lib.rs:161-162\`
+
+\`#[allow(unused_assignments)]\` is suppressing a legitimate lint. The \`schema\` variable is initialized to \`Unknown\` then overwritten on the first \`NonRealTimeMeta\` element. Could be cleaner as a direct call once the element is encountered. Style only.
+
+## Acceptance criteria
+
+- All four items addressed.
+- No behavior change visible to consumers (these are internal hygiene items).
+- Validation per \`.loswf/config.yaml\` passes.
+
+## Out of scope
+
+- Tightening the synthetic-fixture integration test to assert all 12 normalized fields → separate issue.
+- Sidecar-aware smoke harness in XIFtyNode → separate issue (different repo).

--- a/specs/drafts/129-test-coverage.md
+++ b/specs/drafts/129-test-coverage.md
@@ -1,0 +1,23 @@
+## Context
+
+Reviewer finding from PR #127 (Phase 1 sidecar framework + Sony NRT adapter, #122).
+
+## Problem
+
+The synthetic-fixture integration test \`sony_nrt_sidecar_synthetic_minimal_fixture_lifts_fields\` in \`crates/xifty-cli/tests/cli_contract.rs\` asserts 9 of the 12 normalized fields lifted by \`derive_sony_nrt_fields\`. Three are missing:
+
+- \`timecode.half_step\`
+- \`recording.cache_rec\`
+- \`device.serial_no\`
+
+All three are present in the synthetic fixture XML and are correctly lifted at the unit-test level (\`lifts_sony_nrt_sidecar_fields_from_namespace\` in \`xifty-normalize\` covers all 12). The integration test is the load-bearing one for the cross-crate pipeline; coverage gap means a regression in the CLI dispatch path or normalize wiring for any of these three fields wouldn't be caught by the integration test alone.
+
+## Fix
+
+Add the three missing assertions to the integration test. Single-line additions per field; trivial.
+
+## Acceptance criteria
+
+- All 12 normalized fields lifted by Phase 1 are asserted by the integration test.
+- Test still skips cleanly if the synthetic fixture has not been generated.
+- Validation per \`.loswf/config.yaml\` passes.


### PR DESCRIPTION
## Summary

Phase 1 sidecar reviewer follow-ups from PR #127. No behavior change visible to consumers — these are hygiene + test-coverage items.

### Changes from #128

- **`SIDECAR_PARSE_ERROR` is now a `pub const`.** Lives in `xifty-sidecar` alongside the four existing constants. Sony NRT adapter switched from raw string literal to the constant.
- **`MergePolicy::Override` doc rewritten.** Old comment claimed the conflict detector saw both values; actual behavior silently replaces. Doc now states this clearly and points at Adobe XMP sidecars as the canonical use case for Phase 4 (#125). Inline comment in `merge_into` updated to match.
- **`attr_value` entity-decoding decision: documented assumption.** Sony NRT XSD ver.2.10 / ver.2.20 attribute payloads are all ASCII-clean tokens (UMID hex, FPS strings, codec names, SMPTE timecodes, serial numbers, enum values). No real-world camera output carries entity references, and threading `reader.decoder()` through 25+ callsites and `detect_schema` is invasive. Added a doc comment on `attr_value` explaining the choice and what would trigger a switch to `decode_and_unescape_value`. The plan offered both options and asked us to pick the cleaner one — the documented-assumption path keeps the diff minimal until a real fixture demands the change.
- **Style cleanup.** Removed `#[allow(unused_assignments)]`; `schema` is now a single immutable `let` scoped to the `NonRealTimeMeta` branch where it's actually used.
- **Docs.** `docs/SCHEMA_POLICY.md` now lists all five stable sidecar issue codes (previously only `sidecar_discovery_unavailable_in_wasm` was named).

### Changes from #129

- **Tightened integration test to all 12 normalized fields.** Added `timecode.half_step` and `recording.cache_rec` to `sony_nrt_sidecar_synthetic_minimal_fixture_lifts_fields`. (`device.serial_no` was already asserted; the issue's "9 of 12" was off-by-one but the goal — assert every field `derive_sony_nrt_fields` lifts — is now met.) Added a comment pointing at the unit-test that must stay in lockstep.

The synthetic fixture at `fixtures/minimal/sony-nrt/clipM01.XML` already contains `halfStep="true"`, `cacheRec="false"`, and `serialNo="0123456"` — no fixture regeneration needed.

Per-tag XSD source citations preserved on every touched line. 100% native Rust.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --all-features`
- [x] `cargo test -p xifty-ffi --all-features`
- [x] `python3 tools/generate_capabilities.py --check`

Closes #128
Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)